### PR TITLE
Enhance pack-card hover visuals

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -45,3 +45,24 @@ a:hover, button:hover {
   background-color: #999;
 }
 
+/* Hover floating effect for pack cards */
+.pack-card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.pack-card:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(135deg,
+    rgba(255, 255, 255, 0.25) 0%,
+    rgba(255, 255, 255, 0.1) 40%,
+    rgba(255, 255, 255, 0.05) 60%,
+    rgba(255, 255, 255, 0) 100%
+  ), #222;
+}
+
+@media (max-width: 600px) {
+  .pack-card {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add floating card and metallic gradient hover effects for `.pack-card`
- keep base layout while making cards responsive on mobile

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6870633ebb8083259bce4cd013f9b4db