### PR TITLE
Agregar categorías, estilo de código y página de Servicios

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,5 @@ No hay trackers. No hay plugins innecesarios. Todo está escrito con intención.
 
 🜂 Este README no es un resumen. Es una semilla.
 El resto se revelará en la acción.
+Con cada paso de la bestia, nacen nuevas sendas para quienes nos siguen.
 """

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ def init_db():
         CREATE TABLE topics (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           title TEXT,
+          category TEXT,
           description TEXT,
           image TEXT,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -48,6 +49,14 @@ def index():
     packs = cargar_packs()
     return render_template('index.html', packs=packs)
 
+@app.route('/services')
+def services():
+    return render_template('services.html')
+
+@app.route('/academia')
+def academia():
+    return render_template('proximamente.html')
+
 @app.route('/pack/<string:pack_id>')
 def ver_pack(pack_id):
     packs = cargar_packs()
@@ -66,12 +75,14 @@ def forum_index():
 def forum_new():
     if request.method == 'POST':
         title = request.form['title']
+        category = request.form['category']
         description = request.form.get('description')
         image_file = request.files.get('image')
         image = image_file.filename if image_file and image_file.filename else None
-        forum_db.create_topic(title, description, image)
+        forum_db.create_topic(title, category, description, image)
         return redirect('/forum')
-    return render_template('forum_new.html')
+    categories = forum_db.get_categories()
+    return render_template('forum_new.html', categories=categories)
 
 @app.route('/forum/<int:id>')
 def forum_topic(id):

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -4,6 +4,26 @@ from typing import List, Dict
 
 DB_PATH = 'db/forum.db'
 
+# Categorías disponibles para los temas del foro
+CATEGORIES = [
+    "Grabación en vivo",
+    "Diseño de sonido",
+    "Foley y efectos",
+    "Edición de audio",
+    "Mezcla y masterización",
+    "Micrófonos y equipos",
+    "Flujo de trabajo DAW",
+    "Ambientes y field recording",
+    "Postproducción de vídeo",
+    "Plugins y herramientas",
+    "Formatos y codecs",
+    "Consejos de producción",
+]
+
+def get_categories() -> List[str]:
+    """Devuelve la lista de categorías predefinidas."""
+    return CATEGORIES
+
 def _connect():
     return sqlite3.connect(DB_PATH)
 
@@ -34,13 +54,13 @@ def get_posts(topic_id: int) -> List[Dict]:
     conn.close()
     return [dict(row) for row in rows]
 
-def create_topic(title: str, description: str = None, image: str = None) -> int:
+def create_topic(title: str, category: str, description: str = None, image: str = None) -> int:
     """Crea un nuevo tema en la tabla topics."""
     conn = _connect()
     cur = conn.cursor()
     cur.execute(
-        'INSERT INTO topics (title, description, image, created_at) VALUES (?,?,?,?)',
-        (title, description, image, datetime.utcnow())
+        'INSERT INTO topics (title, category, description, image, created_at) VALUES (?,?,?,?,?)',
+        (title, category, description, image, datetime.utcnow())
     )
     conn.commit()
     topic_id = cur.lastrowid

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;900&family=Montserrat:wght@400;700&display=swap');
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Montserrat', sans-serif;
   background-color: #000;
   color: #fff;
   margin: 0;
@@ -24,9 +24,10 @@ body {
 
 .logo-text {
   font-weight: 900;
-  font-size: 1.2rem;
+  font-size: 2rem;
   letter-spacing: 2px;
   color: #fff;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .nav {
@@ -76,6 +77,28 @@ body {
 }
 
 .pack-card img {
+  width: 100%;
+  border-radius: 8px;
+}
+
+/* servicios */
+.services {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.service-card {
+  background: #111;
+  border-radius: 10px;
+  padding: 1rem;
+  width: 280px;
+  text-align: center;
+}
+
+.service-card img {
   width: 100%;
   border-radius: 8px;
 }
@@ -180,15 +203,31 @@ a:hover, button:hover {
   width: 25%;
 }
 
+
 .topics, .posts {
   width: 70%;
+  display: grid;
+  gap: 1rem;
 }
 
 .topic-card, .post-card {
   background: #111;
+  border: 1px solid #333;
+  border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
-  border-radius: 5px;
+}
+
+
+.topic-card h3 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 900;
+}
+
+.post-card p,
+.topic-card p {
+  font-family: Consolas, 'Courier New', monospace;
+  color: #888;
 }
 
 .vote-button {

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,17 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}Verité{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
   <header class="header">
     <a href="/" class="logo-text">VERITÉ</a>
     <nav class="nav">
-      <a href="#" class="nav-link underline-animated">ABOUT</a>
-      <a href="#" class="nav-link underline-animated">WORK</a>
-      <a href="#" class="nav-link underline-animated">QUOTE</a>
+      <a href="/" class="nav-link underline-animated">INICIO</a>
+      <a href="/" class="nav-link underline-animated">PACKS</a>
+      <a href="/services" class="nav-link underline-animated">SERVICES</a>
       <a href="/forum" class="nav-link underline-animated">VFORUM</a>
-      <a href="#" class="nav-link underline-animated">FAQ</a>
+      <a href="/academia" class="nav-link underline-animated">ACADEMIA</a>
     </nav>
   </header>
 

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -17,7 +17,8 @@
   <section class="topics">
     {% for t in topics %}
     <div class="topic-card">
-      <h2><a href="/forum/{{ t.id }}">{{ t.title }}</a></h2>
+      <h3><a href="/forum/{{ t.id }}">{{ t.title }}</a></h3>
+      <p>{{ t.category }}</p>
       <p>{{ t.created_at }}</p>
       <p>Votos: {{ t.votes }}</p>
       {% if t.description %}<p>{{ t.description }}</p>{% endif %}

--- a/templates/forum_new.html
+++ b/templates/forum_new.html
@@ -6,6 +6,11 @@
 <h1>Crear nuevo tema</h1>
 <form action="/forum/new" method="post" enctype="multipart/form-data">
   <input type="text" name="title" placeholder="Título" required>
+  <select name="category" required>
+    {% for c in categories %}
+    <option value="{{ c }}">{{ c }}</option>
+    {% endfor %}
+  </select>
   <textarea name="description" placeholder="Descripción" required></textarea>
   <input type="file" name="image" accept="image/*">
   <button type="submit">Publicar</button>

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -6,6 +6,7 @@
 <div class="forum-container">
   <section class="posts">
     <h1>{{ topic.title }}</h1>
+    <p>{{ topic.category }}</p>
     {% if topic.image %}
       <img src="{{ topic.image }}" alt="{{ topic.title }}">
     {% endif %}

--- a/templates/proximamente.html
+++ b/templates/proximamente.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block title %}Próximamente{% endblock %}
+
+{% block content %}
+  <h1>Próximamente</h1>
+  <p>Esta sección estará disponible pronto.</p>
+{% endblock %}

--- a/templates/services.html
+++ b/templates/services.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% block title %}Servicios{% endblock %}
+
+{% block content %}
+  <h1>Servicios</h1>
+  <div class="services">
+    <div class="service-card">
+      <img src="/static/img/pack1.jpg" alt="Grabación de campo">
+      <h2>Grabación de campo</h2>
+      <p>Captura profesional en exteriores.</p>
+      <a href="#">Ver detalle</a>
+    </div>
+    <div class="service-card">
+      <img src="/static/img/pack2.jpg" alt="Consultoría audiovisual">
+      <h2>Consultoría audiovisual</h2>
+      <p>Asesoría para tus proyectos de sonido.</p>
+      <a href="#">Ver detalle</a>
+    </div>
+    <div class="service-card">
+      <img src="/static/img/pack3.jpg" alt="Edición avanzada">
+      <h2>Edición avanzada</h2>
+      <p>Mejoramos y limpiamos tu audio.</p>
+      <a href="#">Ver detalle</a>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Cambios incluidos
- Se definieron 12 categorías para VFORUM y se guardan al crear cada tema
- Formulario con menú desplegable para elegir la categoría
- Estilo "hacker" con tipografía Inter para títulos y monospace en textos
- Header unificado con logo más grande y enlaces a INICIO, PACKS, SERVICES, VFORUM y ACADEMIA
- Nueva ruta `/services` con plantilla de ejemplo y página temporal para `/academia`
- Actualización de README con línea narrativa adicional

------
https://chatgpt.com/codex/tasks/task_e_687080d74648832585add769c054b8ef