### PR TITLE
Fix: endpoint 'forum' y actualizar url_for en plantillas

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ def ver_pack(pack_id):
 
 # ---------------- VFORUM ----------------
 @app.route('/forum')
-def forum_index():
+def forum():
     topics = forum_db.get_topics()
     return render_template('forum_index.html', topics=topics)
 

--- a/templates/pack.html
+++ b/templates/pack.html
@@ -12,7 +12,7 @@
       <a href="#" class="nav-link">ABOUT</a>
       <a href="#" class="nav-link">WORK</a>
       <a href="#" class="nav-link">QUOTE</a>
-      <a href="/forum" class="nav-link">VFORUM</a>
+      <a href="{{ url_for('forum') }}" class="nav-link">VFORUM</a>
       <a href="#" class="nav-link">FAQ</a>
     </nav>
   </header>


### PR DESCRIPTION
## Resumen
- Renombrar la función `forum_index` a `forum` para que coincida con el endpoint `/forum`
- Actualizar el enlace a VFORUM en `pack.html` usando `url_for('forum')`
- Revisado que `forum_new` conserve su ruta `/forum/new`

## Testing
- `python app.py` *(falla: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687088755eac8325858554e724b7fd6a