### PR TITLE
fix/route-academia

### DIFF
--- a/templates/forum_new.html
+++ b/templates/forum_new.html
@@ -15,7 +15,7 @@
       <a href="{{ url_for('packs') }}" class="nav-link">PACKS</a>
       <a href="{{ url_for('services') }}" class="nav-link">SERVICES</a>
       <a href="{{ url_for('forum') }}" class="nav-link">VFORUM</a>
-      <a href="{{ url_for('academy') }}" class="nav-link">ACADEMIA</a>
+      <a href="{{ url_for('academia') }}" class="nav-link">ACADEMIA</a>
     </nav>
   </header>
   <main>


### PR DESCRIPTION
## Summary
- replace missing `academia` reference in template
- ensure the `academia` route remains defined

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68709ea0c2788325a98a0e700d25ceb1