### PR TITLE
Home hero layout and latest topic update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Todo camino tiene su propósito...
 Todo proyecto debe ser finalizado.
 Sigue adelante. Te ayudaremos a avanzar.
 Cada huella es testimonio de lo aprendido en el camino.
+El polvo que levantamos revela sendas inéditas.
 
 ──────────────────────────────────────────────
 
@@ -93,3 +94,4 @@ Con cada paso de la bestia, nacen nuevas sendas para quienes nos siguen.
 ✨ Movida sección “Últimas categorías” al centro + carrusel motivacional audiovisual
 Cada paso deja un eco que resuena en la arena digital.
 ✨ feat: Home renovado, VFORUM completo con UI unificada, categorías fijas, carrusel inspiracional y ruta /academy.
+🔧 Ajustado logo, hero y descripción. Reubicada sección ‘Último tema’ para mejorar la jerarquía visual.

--- a/static/style.css
+++ b/static/style.css
@@ -22,12 +22,14 @@ body {
   z-index: 100;
 }
 
-.logo-text {
-  font-weight: 900;
-  font-size: 8rem;
-  letter-spacing: 0.5rem;
-  color: #fff;
+header .logo {
+  color: #000 !important;
+  letter-spacing: -1px;
+  font-size: 2.5rem;
+  padding: 0.5rem 1rem;
+  line-height: 1;
   font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
 }
 
 .nav {
@@ -284,22 +286,25 @@ a:hover, button:hover {
   }
 }
 
-.hero-title {
+.hero-container {
+  border: 2px solid #fff;
+  padding: 1rem;
+  margin: 2rem auto;
+  max-width: 90%;
+  text-align: center;
+}
+.hero-container h1 {
   font-family: 'Inter', sans-serif;
   font-weight: 900;
-  font-size: clamp(3rem,6vw,6rem);
-  text-align: center;
-  color: #fff;
-  margin: 2rem 0;
+  font-size: clamp(4rem, 8vw, 6rem);
+  margin: 0;
 }
-
-.hero p {
-  font-family: 'Inter', sans-serif;
-  font-weight: 400;
-  font-size: 1.2rem;
+.hero-container p {
   color: #ccc;
-  text-align: center;
-  margin-bottom: 3rem;
+  font-size: 1rem;
+  line-height: 1.2;
+  max-width: 800px;
+  margin: 1rem auto;
 }
 
 .section-title {
@@ -320,23 +325,17 @@ a:hover, button:hover {
   margin-bottom: 3rem;
 }
 
-.latest-topic-card {
+#latest-topic {
   background: #111;
-  border: 1px solid #333;
-  padding: 1rem;
-  margin: 2rem auto;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin: 3rem auto;
   max-width: 800px;
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+  color: #fff;
+  transition: transform .3s ease;
 }
-.latest-topic-card.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.latest-topic-group {
-  margin-bottom: 2rem;
+#latest-topic:hover {
+  transform: translateY(-5px);
 }
 
 .forum-intro {

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,5 +1,5 @@
 <header class="header">
-  <a href="{{ url_for('home') }}" class="logo-text">VERITÉ</a>
+  <a href="{{ url_for('home') }}" class="logo">VERITÉ</a>
   <nav class="nav">
     <a href="{{ url_for('home') }}" class="nav-link">INICIO</a>
     <a href="{{ url_for('packs') }}" class="nav-link">PACKS</a>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,30 +3,11 @@
 {% block title %}Inicio Verité{% endblock %}
 
 {% block content %}
-  <section class="hero">
-    <h1 class="hero-title">CONTENIDO AUDIOVISUAL DE ALTA CALIDAD</h1>
-  </section>
-
-  <section class="que-es">
-    <p>
-      Verité es un ecosistema que promueve la creación audiovisual sin atajos ni filtros artificiales. Registramos cada sonido y cada imagen en terreno, explorando diversas técnicas de grabación en vivo, diseño sonoro y postproducción para ofrecerte resultados auténticos. Nuestro objetivo es que comprendas el proceso completo, desde la captura hasta la edición final, para que puedas integrarlo en tus proyectos sin depender de librerías genéricas. Creemos que el conocimiento compartido fortalece a la comunidad y nos motiva a seguir experimentando y creciendo juntos.
-    </p>
-  </section>
-
-  {% if latest %}
-  <div class="latest-topic-card">
-    <h3><a href="/forum/{{ latest.id }}">{{ latest.title }}</a></h3>
-    <p>{{ latest.description[:300] }}{% if latest.description and latest.description|length > 300 %}...{% endif %}</p>
-    <a href="/forum/{{ latest.id }}" class="read-more">Leer más →</a>
-    <p class="date">{{ latest.created_at }}</p>
+  <div class="hero-container">
+    <h1>CONTENIDO AUDIOVISUAL DE ALTA CALIDAD</h1>
+    <p>Verité promueve la creación audiovisual auténtica. Registramos sonidos e imágenes reales para impulsar tus proyectos sin artificios.</p>
   </div>
-  {% else %}
-  <div class="latest-topic-card">
-    <h3>Ejemplo de tema</h3>
-    <p>Participa en nuestro foro VFORUM</p>
-    <a href="/forum" class="read-more">Leer más →</a>
-  </div>
-  {% endif %}
+
 
   <h2 class="section-title">Packs de sonidos</h2>
   <p class="section-desc">Cada pack surge de grabaciones en terreno y seleccionadas cuidadosamente.</p>
@@ -61,4 +42,13 @@
   <h2 class="section-title">Por Qué Hacemos Esto</h2>
   <p class="section-desc">La industria olvida la humanidad detrás de cada proyecto. Nosotros grabamos lo que vivimos.</p>
   <p class="section-desc">Con cada servicio y pack apoyamos a creadores reales que buscan contar historias honestas.</p>
+
+  <section id="latest-topic">
+    {% if latest %}
+      <h3><a href="/forum/{{ latest.id }}">{{ latest.title }}</a></h3>
+      <p>{{ latest.description[:300] }}{% if latest.description and latest.description|length > 300 %}...{% endif %}</p>
+      <a href="/forum/{{ latest.id }}" class="read-more">Leer más →</a>
+      <p class="date">{{ latest.created_at }}</p>
+    {% endif %}
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- tweak header logo style
- wrap hero in `.hero-container` and shorten intro text
- move forum preview section to bottom
- restyle latest topic block
- log changes in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68728bf834588325adf2d503bf395bca