### PR TITLE
Mejora: logo interactivo Montserrat blanco en header

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;900&family=Montserrat:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@900&display=swap');
 
 body {
   font-family: 'Montserrat', sans-serif;
@@ -22,14 +23,24 @@ body {
   z-index: 100;
 }
 
-header .logo {
-  color: #000 !important;
-  letter-spacing: -1px;
-  font-size: 2.5rem;
-  padding: 0.5rem 1rem;
-  line-height: 1;
+.logo {
   font-family: 'Montserrat', sans-serif;
   font-weight: 900;
+  font-size: 2.5rem;
+  color: #fff;
+  background: none;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.logo:hover {
+  transform: scale(1.1);
+}
+
+.logo:active {
+  transform: scale(1.05);
 }
 
 .nav {

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,5 +1,9 @@
 <header class="header">
-  <a href="{{ url_for('home') }}" class="logo">VERITÉ</a>
+  {% if request.endpoint != 'home' %}
+    <a href="{{ url_for('home') }}" class="logo">VERITÉ</a>
+  {% else %}
+    <span class="logo">VERITÉ</span>
+  {% endif %}
   <nav class="nav">
     <a href="{{ url_for('home') }}" class="nav-link">INICIO</a>
     <a href="{{ url_for('packs') }}" class="nav-link">PACKS</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>{% block title %}Verité{% endblock %}</title>
   <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- integrate interactive logo using conditional link in `_header.html`
- use Montserrat 900 font
- style `.logo` class for hover/active scaling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687293761c3c8325815509575feb3063