### PR TITLE
Mejora: logo ampliado y descripciones más compactas

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -26,9 +26,12 @@ body {
 .logo {
   font-family: 'Montserrat', sans-serif;
   font-weight: 900;
-  font-size: 2.5rem;
+  font-size: 3.5rem;
+  max-width: 100%;
+  white-space: nowrap;
   color: #fff;
   background: none;
+  margin-right: auto;
   text-decoration: none;
   transition: transform 0.2s ease;
   display: inline-block;
@@ -334,6 +337,14 @@ a:hover, button:hover {
   color: #ccc;
   text-align: center;
   margin-bottom: 3rem;
+}
+
+.section-description {
+  font-size: 1.1rem;
+  line-height: 1.4;
+  color: #ccc;
+  max-width: 800px;
+  margin: 1rem auto 3rem;
 }
 
 #latest-topic {

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,9 +1,5 @@
 <header class="header">
-  {% if request.endpoint != 'home' %}
-    <a href="{{ url_for('home') }}" class="logo">VERITÉ</a>
-  {% else %}
-    <span class="logo">VERITÉ</span>
-  {% endif %}
+  <a href="{{ url_for('home') }}" class="logo">VERITÉ</a>
   <nav class="nav">
     <a href="{{ url_for('home') }}" class="nav-link">INICIO</a>
     <a href="{{ url_for('packs') }}" class="nav-link">PACKS</a>

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,9 +10,9 @@
 
 
   <h2 class="section-title">Packs de sonidos</h2>
-  <p class="section-desc">Cada pack surge de grabaciones en terreno y seleccionadas cuidadosamente.</p>
-  <p class="section-desc">Queremos que conectes con la esencia de cada lugar sin recurrir a sonidos genéricos.</p>
-  <p class="section-desc">Nuestra misión es que tus proyectos respiren autenticidad en cada detalle.</p>
+  <p class="section-description">Cada pack surge de grabaciones en terreno y seleccionadas cuidadosamente.</p>
+  <p class="section-description">Queremos que conectes con la esencia de cada lugar sin recurrir a sonidos genéricos.</p>
+  <p class="section-description">Nuestra misión es que tus proyectos respiren autenticidad en cada detalle.</p>
   <div class="packs">
     {% for pack in packs %}
     <div class="pack-card">
@@ -26,8 +26,8 @@
   </div>
 
   <h2 class="section-title">Servicios Audiovisuales</h2>
-  <p class="section-desc">Nos involucramos desde la captura hasta la postproducción para que tu mensaje suene real.</p>
-  <p class="section-desc">Creemos que imagen y sonido deben nacer juntos y crecer en armonía.</p>
+  <p class="section-description">Nos involucramos desde la captura hasta la postproducción para que tu mensaje suene real.</p>
+  <p class="section-description">Creemos que imagen y sonido deben nacer juntos y crecer en armonía.</p>
   <div class="services">
     {% for s in services %}
     <div class="service-card">

--- a/templates/packs.html
+++ b/templates/packs.html
@@ -4,8 +4,8 @@
 
 {% block content %}
   <h1 class="section-title">PACKS</h1>
-  <p class="section-desc">Nuestros packs nacen de sesiones reales y buscan aportar texturas auténticas.</p>
-  <p class="section-desc">Seleccionamos lo que de verdad sirve para contar historias con sonido propio.</p>
+  <p class="section-description">Nuestros packs nacen de sesiones reales y buscan aportar texturas auténticas.</p>
+  <p class="section-description">Seleccionamos lo que de verdad sirve para contar historias con sonido propio.</p>
   <div class="packs">
     {% for pack in packs %}
     <div class="pack-card">

--- a/templates/services.html
+++ b/templates/services.html
@@ -4,8 +4,8 @@
 
 {% block content %}
   <h1 class="section-title">SERVICIOS</h1>
-  <p class="section-desc">Acompañamos cada etapa de tu proyecto con soluciones reales.</p>
-  <p class="section-desc">Nuestro compromiso es brindar un sonido limpio y coherente con tu visión.</p>
+  <p class="section-description">Acompañamos cada etapa de tu proyecto con soluciones reales.</p>
+  <p class="section-description">Nuestro compromiso es brindar un sonido limpio y coherente con tu visión.</p>
   <div class="services">
     {% for s in services %}
     <div class="service-card">


### PR DESCRIPTION
## Summary
- enlarge logo in header by using text link and bigger styling
- tweak description paragraphs for packs and services sections
- add `.section-description` rule for compact text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68729a474b848325924f031fbe1d2866