### PR TITLE
Remove hero filmstrip design

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ Cada paso deja un eco que resuena en la arena digital.
 🔧 Ajustado logo, hero y descripción. Reubicada sección ‘Último tema’ para mejorar la jerarquía visual.
 La criatura crece y cada mejora afianza su presencia entre los nómadas digitales.
 Sus huellas digitales marcan el rumbo de nuevas alianzas creativas.
+El camino despejado permite contemplar nuevas constelaciones de colaboraci\u00f3n.

--- a/static/style.css
+++ b/static/style.css
@@ -548,46 +548,10 @@ body.forum-new {
   opacity: 1;
 }
 
-/* Contenedor para el efecto tira de cine */
+/* Contenedor héroe */
 .hero-title-container {
   position: relative;
-  overflow: hidden;
   padding: 2rem;
-}
-.hero-title-container::before,
-.hero-title-container::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 12px;
-  background: repeating-linear-gradient(
-    to right,
-    #fff 0,
-    #fff 40px,
-    transparent 40px,
-    transparent 60px
-  );
-  border-radius: 4px;
-  z-index: 1;
-}
-.hero-title-container::before { top: 0; }
-.hero-title-container::after { bottom: 0; }
-
-/* Animación por defecto */
-@keyframes filmRoll {
-  from { background-position: 0 0; }
-  to   { background-position: -100px 0; }
-}
-.hero-title-container::before,
-.hero-title-container::after {
-  animation: filmRoll 6s linear infinite;
-}
-
-/* Al pasar el ratón sobre el contenedor héroe, acelera la animación */
-.hero-title-container:hover::before,
-.hero-title-container:hover::after {
-  animation-duration: 3s;
 }
 
 /* Asegura que el texto esté por encima */
@@ -595,43 +559,4 @@ body.forum-new {
 .hero-title-container p {
   position: relative;
   z-index: 2;
-}
-
-/* Contenedor oculto overflow y posición */
-.filmstrip-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1.5rem;
-  overflow: hidden;
-  pointer-events: none;
-}
-
-/* Fila continua */
-.filmstrip {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  animation: scroll-film 10s linear infinite;
-}
-
-/* Rectángulos con bordes redondeados */
-.filmrect {
-  width: 2rem;
-  height: 0.5rem;
-  background: #fff;
-  border-radius: 0.25rem;
-  flex-shrink: 0;
-}
-
-/* Animación: de izquierda a derecha */
-@keyframes scroll-film {
-  0% { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
-}
-
-/* Acelerar/ralentizar on hover */
-.filmstrip-container:hover .filmstrip {
-  animation-duration: 5s;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,13 +4,6 @@
 
 {% block content %}
   <div class="hero-container">
-    <div class="filmstrip-container">
-      <div class="filmstrip">
-        {% for i in range(20) %}
-        <span class="filmrect"></span>
-        {% endfor %}
-      </div>
-    </div>
     <div class="hero-title-container">
       <h1>CONTENIDO AUDIOVISUAL DE ALTA CALIDAD</h1>
       <p>Verité promueve la creación audiovisual auténtica. Registramos sonidos e imágenes reales para impulsar tus proyectos sin artificios.</p>


### PR DESCRIPTION
## Summary
- drop filmstrip elements from home hero and CSS
- add another line to README story

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872a97b812883259c1930aabe819596