### PR TITLE
Add inspirational carousel to forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ Cada paso deja un eco que resuena en la arena digital.
 La criatura crece y cada mejora afianza su presencia entre los nómadas digitales.
 Sus huellas digitales marcan el rumbo de nuevas alianzas creativas.
 El camino despejado permite contemplar nuevas constelaciones de colaboraci\u00f3n.
+Nuevas voces se unen, fortaleciendo la resonancia de la bestia en cada rinc\u00f3n digital.

--- a/app.py
+++ b/app.py
@@ -79,7 +79,12 @@ def ver_pack(pack_id):
 # ---------------- VFORUM ----------------
 @app.route('/forum')
 def forum_index():
-    return render_template('forum_index.html', categories=forum_db.get_categories(), topics=forum_db.get_all_topics())
+    return render_template(
+        'forum_index.html',
+        categories=forum_db.get_categories(),
+        topics=forum_db.get_all_topics(),
+        quotes=forum_db.INSPIRATIONAL_QUOTES,
+    )
 
 @app.route('/forum/new', methods=['GET', 'POST'])
 def forum_new():

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -20,6 +20,50 @@ FIXED_CATEGORIES = [
     "Consejos de producción",
 ]
 
+# 40 frases motivacionales para el carrusel de VFORUM
+INSPIRATIONAL_QUOTES = [
+    "La cooperación impulsa la creatividad",
+    "Compartir ideas expande el universo de posibilidades",
+    "La innovación nace del diálogo entre mentes",
+    "Confía en la sincronicidad para hallar nuevas rutas",
+    "La imaginación florece en la mirada del otro",
+    "Cada colaborador aporta una chispa distinta",
+    "Los proyectos en conjunto revelan paisajes inauditos",
+    "Explorar tus límites abre espacios de comunión",
+    "Al escuchar surge la verdadera visión",
+    "El trabajo cooperativo transforma la realidad",
+    "Cambia de perspectiva y encuentra nuevas armonías",
+    "Conectar es la fuerza que mueve el arte",
+    "Una red de creadores es un cosmos en expansión",
+    "Cada conversación puede ser un portal de inspiración",
+    "Celebra la diferencia para alcanzar la unidad",
+    "Lo imposible se moldea con la voluntad colectiva",
+    "Juntos trazamos caminos donde antes solo hubo niebla",
+    "Entretejer voces nos hace trascender el ego",
+    "El arte florece cuando se nutre de múltiples miradas",
+    "Una idea compartida germina en mil formas",
+    "Suma tu energía al pulso creativo de la comunidad",
+    "Atrévete a construir más allá de tus límites",
+    "La colaboración es un viaje hacia lo desconocido",
+    "Cuando nos reunimos, el tiempo cobra otro ritmo",
+    "El aprendizaje mutuo amplifica nuestras visiones",
+    "Abrirse a la crítica es abrazar la mejora",
+    "La curiosidad conjunta disuelve fronteras",
+    "Vibra con tus pares y nace una nueva frecuencia",
+    "El cambio surge de la conversación honesta",
+    "Lanza tus dudas al espacio compartido",
+    "Cada experiencia sumada dibuja un mapa mayor",
+    "La coherencia colectiva crea realidades palpables",
+    "Exploramos lo desconocido con valentía compartida",
+    "Transformamos el caos en oportunidades creativas",
+    "Comparte y observa cómo brota la sinergia",
+    "Resonamos con el ritmo de la colaboración continua",
+    "Tus pasos inspiran a quienes caminan a tu lado",
+    "La conexión sincera despierta potenciales ocultos",
+    "Colaborar es multiplicar la energía creativa",
+    "Construir juntos hace que cada proyecto sea único",
+]
+
 def get_categories() -> List[str]:
     """Devuelve la lista de categorías predefinidas."""
     return FIXED_CATEGORIES

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -27,15 +27,3 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-document.addEventListener('DOMContentLoaded', () => {
-  const cards = document.querySelectorAll('.motivation-card');
-  if (cards.length) {
-    let idx = 0;
-    cards[idx].classList.add('visible');
-    setInterval(() => {
-      cards[idx].classList.remove('visible');
-      idx = (idx + 1) % cards.length;
-      cards[idx].classList.add('visible');
-    }, 8000);
-  }
-});

--- a/static/style.css
+++ b/static/style.css
@@ -259,7 +259,7 @@ a:hover, button:hover {
 }
 
 .topics {
-  width: 60%;
+  width: 100%;
   display: grid;
   gap: 1rem;
 }
@@ -522,30 +522,31 @@ body.forum-new {
 
 .motivation-carousel {
   position: relative;
-  height: 250px;
   overflow: hidden;
-  width: 25%;
+  width: 100%;
+  margin: 1rem 0 2rem;
+  border: 1px solid #333;
+  border-radius: 12px;
+  background: #111;
 }
 
 .motivation-track {
-  position: relative;
-  height: 100%;
+  display: flex;
+  width: max-content;
+  animation: scrollQuotes 60s linear infinite;
 }
 
 .motivation-card {
-  position: absolute;
-  opacity: 0;
-  transition: opacity 1s ease;
-  width: 100%;
-  padding: 1rem;
-  background: #111;
+  flex: 0 0 auto;
+  padding: 1rem 2rem;
   color: #fff;
-  border-radius: 8px;
-  box-sizing: border-box;
+  white-space: nowrap;
+  font-size: 1rem;
 }
 
-.motivation-card.visible {
-  opacity: 1;
+@keyframes scrollQuotes {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
 }
 
 /* Contenedor héroe */

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -10,26 +10,12 @@
 <div class="forum-container">
   <section class="motivation-carousel">
     <div class="motivation-track">
-      <div class="motivation-card visible">Compartir conocimiento nos hace más fuertes</div>
-      <div class="motivation-card">La cooperación impulsa la creatividad</div>
-      <div class="motivation-card">Cada duda es una oportunidad de aprender</div>
-      <div class="motivation-card">El apoyo mutuo enriquece nuestras obras</div>
-      <div class="motivation-card">Escuchar inspira nuevas visiones</div>
-      <div class="motivation-card">Participa y verás crecer tus ideas</div>
-      <div class="motivation-card">Juntos construimos soluciones reales</div>
-      <div class="motivation-card">El intercambio alimenta la innovación</div>
-      <div class="motivation-card">Preguntar es el primer paso al saber</div>
-      <div class="motivation-card">La comunidad impulsa el progreso</div>
-      <div class="motivation-card">Tus aportes inspiran a otros creadores</div>
-      <div class="motivation-card">Comparte tu experiencia, suma valor</div>
-      <div class="motivation-card">La curiosidad mantiene viva la pasión</div>
-      <div class="motivation-card">El respeto fortalece nuestros lazos</div>
-      <div class="motivation-card">Ayudar también es crecer</div>
-      <div class="motivation-card">Involucrarse abre nuevas puertas</div>
-      <div class="motivation-card">Celebremos cada logro colectivo</div>
-      <div class="motivation-card">Aprender juntos nos hace invencibles</div>
-      <div class="motivation-card">La constancia convierte sueños en realidad</div>
-      <div class="motivation-card">Confía en tu voz para guiar el cambio</div>
+      {% for q in quotes %}
+      <div class="motivation-card">{{ q }}</div>
+      {% endfor %}
+      {% for q in quotes %}
+      <div class="motivation-card">{{ q }}</div>
+      {% endfor %}
     </div>
   </section>
   <section class="topics">


### PR DESCRIPTION
## Summary
- include 40 `INSPIRATIONAL_QUOTES` in `modules/forum.py`
- pass quotes to template from `/forum` route
- build a continuous scrolling carousel on the forum index
- adjust layout styles to fill width and animate smoothly
- remove old JS fading logic
- extend README with a new line

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872cb6016988325a11d292069c9a9b2