### PR TITLE
VFORUM: Layout refine – slider fijo, títulos grandes, demo y delete

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,11 +79,13 @@ def ver_pack(pack_id):
 # ---------------- VFORUM ----------------
 @app.route('/forum')
 def forum_index():
+    latest = forum_db.get_latest_topic()
     return render_template(
         'forum_index.html',
         categories=forum_db.get_categories(),
         topics=forum_db.get_all_topics(),
         quotes=forum_db.INSPIRATIONAL_QUOTES,
+        demo_id=latest['id'] if latest else 0,
     )
 
 @app.route('/forum/new', methods=['GET', 'POST'])
@@ -117,6 +119,12 @@ def vote_post():
     data = request.get_json()
     forum_db.vote_post(data['id'], data['direction'])
     return jsonify(success=True)
+
+@app.route('/forum/<int:id>/delete', methods=['POST'])
+def delete_topic(id):
+    if request.form.get('password') == 'borrar1':
+        forum_db.delete_topic_by_id(id)
+    return redirect(url_for('forum_index'))
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -182,3 +182,12 @@ def vote_post(post_id: int, direction: str) -> None:
         cur.execute('UPDATE posts SET votes = votes - 1 WHERE id=?', (post_id,))
     conn.commit()
     conn.close()
+
+def delete_topic_by_id(topic_id: int) -> None:
+    """Elimina un tema y sus posts asociados."""
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute('DELETE FROM posts WHERE topic_id=?', (topic_id,))
+    cur.execute('DELETE FROM topics WHERE id=?', (topic_id,))
+    conn.commit()
+    conn.close()

--- a/static/style.css
+++ b/static/style.css
@@ -523,24 +523,61 @@ body.forum-new {
   z-index: 2;
 }
 .quote-slider {
-  position: relative;
   width: 100%;
   height: auto;
+  background: #111;
+  border-radius: 1rem;
+  padding: 2rem;
   overflow: hidden;
-  padding: 2rem 0;
 }
 .quote-slide {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%;
   opacity: 0;
-  transition: opacity 1s ease-in-out;
-  color: #fff;
-  font-family: 'Montserrat', sans-serif;
-  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
-  line-height: 1.4;
-  text-align: center;
+  animation: fadeInOut 16s infinite;
 }
-.quote-slide.active {
-  opacity: 1;
+@keyframes fadeInOut {
+  0%, 20% { opacity: 0; }
+  25%, 45% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+.vforum-title {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 4rem;
+  font-weight: 900;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+.vforum-subtitle {
+  font-size: 1.6rem;
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #ccc;
+}
+
+.latest-topic-card {
+  background: #111;
+  border-radius: 1rem;
+  padding: 2rem;
+  margin: 1rem auto;
+  max-width: 800px;
+  color: #fff;
+}
+.latest-topic-card h3 {
+  margin-bottom: 0.5rem;
+}
+.latest-topic-card p {
+  margin-bottom: 1rem;
+  line-height: 1.4;
+}
+.btn-delete {
+  background: transparent;
+  border: 1px solid #f55;
+  color: #f55;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+.btn-delete:hover {
+  background: #f55;
+  color: #000;
 }

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -3,31 +3,22 @@
 {% block title %}VFORUM{% endblock %}
 
 {% block content %}
-<h1 class="section-title">VFORUM</h1>
-<div class="new-topic-container">
-  <a href="/forum/new" class="btn-new">+ Nuevo Tema</a>
+<h1 class="vforum-title">VFORUM</h1>
+<section class="quote-slider">
+  {% for q in quotes %}
+  <div class="quote-slide">{{ q }}</div>
+  {% endfor %}
+</section>
+<div class="vforum-controls" style="text-align:center; margin:2rem 0;">
+  <button class="btn-new-topic">+ Nuevo Tema</button>
 </div>
-<div class="forum-container">
-  <section class="quote-slider">
-    {% for q in quotes %}
-    <div class="quote-slide">{{ q }}</div>
-    {% endfor %}
-  </section>
-  <section class="topics">
-    {% for cat in categories %}
-    <div class="latest-topic-group">
-      <h3>{{ cat }}</h3>
-      {% for t in topics if t.category==cat %}
-        {% if loop.index0 < 3 %}
-        <div class="latest-topic-card">
-          <h4><a href="/forum/{{ t.id }}">{{ t.title }}</a></h4>
-          <p>{{ t.description[:150] }}{% if t.description and t.description|length>150 %}...{% endif %}</p>
-        </div>
-        {% endif %}
-      {% endfor %}
-    </div>
-    {% endfor %}
-  </section>
+<div class="latest-topic-card">
+  <h3>Demo: Problema con mezcla de audio</h3>
+  <p>Ejemplo de cómo se ve el último tema si aún no hay publicaciones reales.</p>
+  <form action="{{ url_for('delete_topic', id=demo_id) }}" method="post">
+    <input type="hidden" name="password" value="borrar1">
+    <button type="submit" class="btn-delete">Eliminar</button>
+  </form>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
- Quitada lista lateral de categorías.
- Slider de frases anclado como descripción (fadeInOut).
- Título y subtítulo doblan tamaño.
- Botón “+ Nuevo Tema” centrado bajo slider.
- Tarjeta “Último tema” con demo y delete (password `borrar1`).
- Endpoint `/forum/<id>/delete` implementado.

------
https://chatgpt.com/codex/tasks/task_e_6872d4036d2483258b921728d083140e