### PR TITLE
Add forum demo topic and redirect behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ Sus huellas digitales marcan el rumbo de nuevas alianzas creativas.
 El camino despejado permite contemplar nuevas constelaciones de colaboraci\u00f3n.
 Nuevas voces se unen, fortaleciendo la resonancia de la bestia en cada rinc\u00f3n digital.
 Paso a paso, la arena digital conserva la memoria de nuestras colaboraciones.
+Cada grano se convierte en sendero para futuros creadores.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, jsonify, url_for
+from flask import Flask, render_template, request, redirect, jsonify, url_for, session
 import json
 import os
 import sqlite3
@@ -38,6 +38,7 @@ init_db()
 from modules import forum as forum_db
 
 app = Flask(__name__)
+app.secret_key = 'demo-secret-key'
 
 # Ruta para cargar info de los packs
 def get_all_packs():
@@ -80,12 +81,18 @@ def ver_pack(pack_id):
 @app.route('/forum')
 def forum_index():
     latest = forum_db.get_latest_topic()
+    existing = forum_db.get_topics()
+    if not existing and not session.get('forum_redirected'):
+        session['forum_redirected'] = True
+        return redirect(url_for('forum_new'))
+    topics, demo_mode = forum_db.get_all_topics()
     return render_template(
         'forum_index.html',
         categories=forum_db.get_categories(),
-        topics=forum_db.get_all_topics(),
+        topics=topics,
         quotes=forum_db.INSPIRATIONAL_QUOTES,
         demo_id=latest['id'] if latest else 0,
+        demo_mode=demo_mode,
     )
 
 @app.route('/forum/new', methods=['GET', 'POST'])

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -1,6 +1,6 @@
 import sqlite3
 from datetime import datetime
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 DB_PATH = 'db/forum.db'
 
@@ -125,8 +125,31 @@ def get_posts(topic_id: int) -> List[Dict]:
     return [dict(row) for row in rows]
 
 # Aliases utilizadas por la aplicación
-def get_all_topics() -> List[Dict]:
-    return get_topics()
+def get_all_topics() -> Tuple[List[Dict], bool]:
+    """Devuelve todos los temas y si se trata de un modo demo."""
+    topics = get_topics()
+    if not topics:
+        topics = [{
+            'id': None,
+            'title': 'Título demo',
+            'body': 'Este es un contenido de demostración. ¡Crea tu primer tema!',
+            'category': None,
+            'created_at': datetime.utcnow(),
+            'likes': 0,
+            'responses': [{
+                'author': 'Demo',
+                'body': 'Respuesta demo',
+                'created_at': datetime.utcnow()
+            }]
+        }]
+        demo_mode = True
+    else:
+        demo_mode = False
+        # Adjuntar votos y respuestas reales
+        for t in topics:
+            t['likes'] = t.get('votes', 0)
+            t['responses'] = get_posts(t['id'])
+    return topics, demo_mode
 
 def get_topic_by_id(topic_id: int) -> Dict:
     return get_topic(topic_id)

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -13,13 +13,24 @@
   <p class="new-topic-desc">Comparte tu duda o aporte con la comunidad.</p>
   <a href="{{ url_for('forum_new') }}" class="btn-new-topic">+ Nuevo Tema</a>
 </div>
-<div class="latest-topic-card">
-  <h3>Demo: Problema con mezcla de audio</h3>
-  <p>Ejemplo de cómo se ve el último tema si aún no hay publicaciones reales.</p>
-  <form action="{{ url_for('delete_topic', id=demo_id) }}" method="post">
-    <input type="hidden" name="password" value="borrar1">
-    <button type="submit" class="btn-delete">Eliminar</button>
-  </form>
+<div class="topic-list">
+  {% for topic in topics %}
+  <div class="topic-card">
+    <h3>{{ topic.title }}</h3>
+    <p>{{ topic.body or topic.description }}</p>
+    <div class="post-actions">
+      <button class="action-btn like">👍 <span>{{ topic.likes }}</span></button>
+      <button class="action-btn comment">💬 {{ topic.responses|length }}</button>
+      <button class="action-btn share">🔗 Compartir</button>
+    </div>
+    {% if topic.id %}
+    <form action="{{ url_for('delete_topic', id=topic.id) }}" method="post">
+      <input type="hidden" name="password" value="borrar1">
+      <button type="submit" class="btn-delete">Eliminar</button>
+    </form>
+    {% endif %}
+  </div>
+  {% endfor %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- display demo topic when database is empty via `get_all_topics`
- store session key to redirect once to `/forum/new`
- render list of topics with actions and conditional delete button
- update README with an additional narrative line

## Testing
- `python -m py_compile app.py modules/forum.py`

------
https://chatgpt.com/codex/tasks/task_e_6872f469825c83259dd527f2ff3c096f