### PR TITLE
add: detalle de tema en VFORUM + respuestas y navegación

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ El camino despejado permite contemplar nuevas constelaciones de colaboraci\u00f3
 Nuevas voces se unen, fortaleciendo la resonancia de la bestia en cada rinc\u00f3n digital.
 Paso a paso, la arena digital conserva la memoria de nuestras colaboraciones.
 Cada grano se convierte en sendero para futuros creadores.
+✨ Se implementa vista de tema individual en VFORUM con estilo EEVI, botón ‘Volver al foro’, lista de respuestas y botón de ‘Añadir respuesta’.

--- a/app.py
+++ b/app.py
@@ -99,14 +99,14 @@ def forum_index():
 def forum_new():
     if request.method == 'POST':
         topic_id = forum_db.create_topic(request.form, request.files)
-        return redirect(url_for('forum_topic', id=topic_id))
+        return redirect(url_for('forum_topic', topic_id=topic_id))
     return render_template('forum_new.html', categories=forum_db.get_categories())
 
-@app.route('/forum/<int:id>')
-def forum_topic(id):
-    topic = forum_db.get_topic_by_id(id)
-    replies = forum_db.get_replies(id)
-    return render_template('forum_topic.html', topic=topic, replies=replies)
+@app.route('/forum/<int:topic_id>')
+def forum_topic(topic_id):
+    topic = forum_db.get_topic_by_id(topic_id)
+    responses = forum_db.get_responses_for_topic(topic_id)
+    return render_template('forum_topic.html', topic=topic, responses=responses)
 
 @app.route('/forum/<int:topic_id>/reply', methods=['POST'])
 def forum_reply(topic_id):

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -157,6 +157,10 @@ def get_topic_by_id(topic_id: int) -> Dict:
 def get_replies(topic_id: int) -> List[Dict]:
     return get_posts(topic_id)
 
+def get_responses_for_topic(topic_id: int) -> List[Dict]:
+    """Alias para obtener las respuestas de un tema."""
+    return get_replies(topic_id)
+
 def create_topic(form, files) -> int:
     """Crea un nuevo tema en la tabla topics a partir de un formulario."""
     title = form['title']

--- a/static/style.css
+++ b/static/style.css
@@ -653,3 +653,58 @@ body.forum-new {
   background: #f55;
   color: #000;
 }
+.forum-topic-container {
+  background: #111;
+  border-radius: 1rem;
+  padding: 2rem;
+  max-width: 800px;
+  margin: 3rem auto;
+  color: #fff;
+}
+.back-btn, .reply-btn {
+  display: inline-block;
+  background: transparent;
+  color: #fff;
+  border: 2px solid #5d5dff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  transition: background 0.2s, color 0.2s;
+}
+.back-btn:hover, .reply-btn:hover {
+  background: #5d5dff;
+  color: #000;
+}
+.topic-title {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+.topic-meta, .response-meta {
+  font-size: 0.9rem;
+  color: #aaa;
+  margin-bottom: 1rem;
+}
+.topic-body, .response-body {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+.response-card {
+  background: #222;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+.responses-title {
+  font-size: 1.5rem;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+.no-resp {
+  font-style: italic;
+  color: #ccc;
+  margin-bottom: 2rem;
+}

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -3,27 +3,21 @@
 {% block title %}{{ topic.title }}{% endblock %}
 
 {% block content %}
-<div class="forum-container">
-  <section class="posts">
-    <h1 class="topic-title">{{ topic.title }}</h1>
-    <p>{{ topic.category }}</p>
-    {% if topic.image %}
-      <img src="{{ topic.image }}" alt="{{ topic.title }}">
-    {% endif %}
-    <pre class="topic-description">{{ topic.description }}</pre>
-
-    {% for r in replies %}
-    <div class="post-card">
-      <p>{{ r.author }} — {{ r.created_at }}</p>
-      <p>{{ r.content }}</p>
+<div class="forum-topic-container">
+  <button onclick="window.location.href='{{ url_for('forum_index') }}'" class="back-btn">← Volver al foro</button>
+  <h1 class="topic-title">{{ topic.title }}</h1>
+  <p class="topic-meta">Categoría: {{ topic.category }} • {{ topic.created_at.strftime('%d %b %Y, %H:%M') }}</p>
+  <div class="topic-body">{{ topic.description }}</div>
+  <hr/>
+  <h2 class="responses-title">Respuestas</h2>
+  {% for r in responses %}
+    <div class="response-card">
+      <p class="response-body">{{ r.content or r.body }}</p>
+      <p class="response-meta">por {{ r.author }} • {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</p>
     </div>
-    {% endfor %}
-
-    <form action="/forum/{{ topic.id }}/reply" method="post">
-      <input type="text" name="author" placeholder="Autor" required>
-      <textarea name="content" placeholder="Respuesta" required></textarea>
-      <button type="submit">Responder</button>
-    </form>
-  </section>
+  {% else %}
+    <p class="no-resp">Sé el primero en responder este tema.</p>
+  {% endfor %}
+  <a href="{{ url_for('forum_new') }}" class="reply-btn">Añadir respuesta</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
- Ruta /forum/<topic_id> para ver tema individual y redirección tras crear
- Nuevo template `forum_topic.html` con estilo EEVI y botón volver
- Estilos añadidos para contenedor de tema, botones y tarjetas de respuesta
- Actualización de README con breve mención al nuevo detalle

------
https://chatgpt.com/codex/tasks/task_e_6872f6ce3e448325b4bdd33a6f2b1543