### PR TITLE
Add project dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ Nuevas voces se unen, fortaleciendo la resonancia de la bestia en cada rinc\u00f
 Paso a paso, la arena digital conserva la memoria de nuestras colaboraciones.
 Cada grano se convierte en sendero para futuros creadores.
 ✨ Se implementa vista de tema individual en VFORUM con estilo EEVI, botón ‘Volver al foro’, lista de respuestas y botón de ‘Añadir respuesta’.
+Cada paso abre portales insospechados para los creadores del mañana.

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('script-modal');
+  const scriptText = document.getElementById('script-text');
+
+  document.querySelectorAll('.script-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      scriptText.textContent = btn.dataset.script;
+      modal.style.display = 'block';
+    });
+  });
+
+  document.querySelectorAll('.close-modal').forEach(span => {
+    span.addEventListener('click', () => { modal.style.display = 'none'; });
+  });
+
+  document.getElementById('theme-toggle')?.addEventListener('click', () => {
+    document.body.classList.toggle('light-mode');
+  });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -708,3 +708,24 @@ body.forum-new {
   color: #ccc;
   margin-bottom: 2rem;
 }
+
+/* Dashboard */
+.dashboard-container { padding: 2rem; }
+.dashboard-login { max-width: 400px; margin: 2rem auto; background:#111; padding:2rem; border-radius:8px; }
+.dashboard-login input { width:100%; padding:.5rem; margin:.5rem 0; background:#222; border:1px solid #333; color:#fff; }
+.dashboard-header { display:flex; justify-content:space-between; align-items:center; }
+.stats { display:flex; flex-wrap:wrap; gap:1rem; margin:1rem 0; }
+.stat-card { background:#111; padding:1rem; border-radius:8px; }
+.projects { display:flex; flex-wrap:wrap; gap:1rem; }
+.project-card { background:#111; padding:1rem; border-radius:8px; max-width:300px; }
+.progress { background:#333; height:8px; border-radius:4px; margin-bottom:.5rem; }
+.progress-bar { background:#5C5CFF; height:8px; border-radius:4px; }
+.scripts-list { list-style:none; padding:0; }
+.scripts-list li { margin-bottom:.5rem; }
+.profile-pic { width:120px; height:120px; border-radius:50%; object-fit:cover; }
+.modal { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.8); display:flex; justify-content:center; align-items:center; }
+.modal-content { background:#111; padding:1rem; border-radius:8px; max-height:80vh; overflow:auto; color:#fff; width:90%; max-width:600px; }
+.light-mode { background:#f0f0f0; color:#000; }
+.light-mode .header { background:#fff; }
+.light-mode .nav-link { color:#000; }
+.light-mode .stat-card, .light-mode .project-card, .light-mode .dashboard-login { background:#e0e0e0; color:#000; }

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -6,5 +6,6 @@
     <a href="{{ url_for('services') }}" class="nav-link">SERVICES</a>
     <a href="{{ url_for('forum_index') }}" class="nav-link">VFORUM</a>
     <a href="{{ url_for('academy') }}" class="nav-link">ACADEMIA</a>
+    <a href="{{ url_for('dashboard') }}" class="nav-link">DASHBOARD</a>
   </nav>
 </header>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+<div class="dashboard-container">
+  {% if not user %}
+  <div class="dashboard-login">
+    <h2>Acceso al Dashboard</h2>
+    <form method="POST">
+      <input type="email" name="email" placeholder="Email" required>
+      <input type="password" name="password" placeholder="Contrase\u00f1a" required>
+      <button type="submit">Entrar</button>
+    </form>
+  </div>
+  {% else %}
+  <div class="dashboard-header">
+    <h2>Bienvenido, {{ user.email }}</h2>
+    <button id="theme-toggle">Modo</button>
+    <form action="{{ url_for('logout') }}" method="post" style="display:inline;">
+      <button type="submit">Salir</button>
+    </form>
+  </div>
+
+  <div class="stats">
+    <div class="stat-card">Proyectos activos: {{ stats.active }}</div>
+    <div class="stat-card">Proyectos terminados: {{ stats.completed }}</div>
+    <div class="stat-card">Guiones: {{ stats.scripts }}</div>
+    <div class="stat-card">Pagos pendientes: {{ stats.pending }}</div>
+  </div>
+
+  <h3>Proyectos Activos</h3>
+  <div class="projects">
+    {% for p in active_projects %}
+    <div class="project-card">
+      <h4>{{ p.title }}</h4>
+      <div class="progress">
+        <div class="progress-bar" style="width: {{ p.progress * 100 }}%"></div>
+      </div>
+      <iframe src="{{ p.video_url }}" allow="autoplay" allowfullscreen></iframe>
+      {% if not p.paid %}<button class="pay-btn">Pagar 50% restante</button>{% endif %}
+    </div>
+    {% endfor %}
+  </div>
+
+  <h3>Proyectos Terminados</h3>
+  <div class="projects">
+    {% for p in completed_projects %}
+    <div class="project-card">
+      <h4>{{ p.title }}</h4>
+      <a href="{{ p.download }}">Descargar</a>
+    </div>
+    {% endfor %}
+  </div>
+
+  <h3>Biblioteca de Guiones</h3>
+  <ul class="scripts-list">
+    {% for p in projects %}
+    <li><button class="script-btn" data-script="{{ p.script|escape }}">{{ p.title }}</button></li>
+    {% endfor %}
+  </ul>
+
+  <div class="profile">
+    <h3>Perfil de Usuario</h3>
+    <img src="{{ user.profile_pic or '/static/img/pack1.jpg' }}" alt="Foto" class="profile-pic">
+    <form action="{{ url_for('upload_profile') }}" method="post" enctype="multipart/form-data">
+      <input type="file" name="photo" accept="image/*" required>
+      <button type="submit">Actualizar foto</button>
+    </form>
+  </div>
+
+  <div id="script-modal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span class="close-modal">&times;</span>
+      <pre id="script-text"></pre>
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/dashboard.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add navigation link for Dashboard
- implement dashboard page with login and project sections
- store simple in-memory users and sample projects
- support profile picture upload and logout
- include new JavaScript and CSS for dashboard
- extend README story

## Testing
- `python -m py_compile app.py modules/forum.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872fa4ebaa88325831022ab171f82b3