### PR TITLE
Implement topic view route with reply form

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ Cada grano se convierte en sendero para futuros creadores.
 ✨ Se implementa vista de tema individual en VFORUM con estilo EEVI, botón ‘Volver al foro’, lista de respuestas y botón de ‘Añadir respuesta’.
 Cada paso abre portales insospechados para los creadores del mañana.
 El eco de nuestro ingenio se entrelaza con el viento de nuevas ideas.
+Las mareas de la comunidad empujan a la bestia a horizontes insondables.

--- a/app.py
+++ b/app.py
@@ -183,7 +183,7 @@ def forum_index():
 def forum_new():
     if request.method == 'POST':
         topic_id = forum_db.create_topic(request.form, request.files)
-        return redirect(url_for('forum_topic', topic_id=topic_id))
+        return redirect(url_for('forum_topic_view', topic_id=topic_id))
     return render_template('forum_new.html', categories=forum_db.get_categories())
 
 @app.route('/forum/<int:topic_id>')
@@ -197,12 +197,21 @@ def forum_topic(topic_id):
                            topic=topic,
                            responses=responses)
 
+@app.route('/forum/tema/<int:topic_id>')
+def forum_topic_view(topic_id):
+    topic = get_topic_by_id(topic_id)
+    if topic is None:
+        flash("\u26a0\ufe0f Tema no encontrado.", "warning")
+        return redirect(url_for('forum_index'))
+    responses = get_responses_for_topic(topic_id)
+    return render_template('forum_topic_view.html', topic=topic, responses=responses)
+
 @app.route('/forum/<int:topic_id>/reply', methods=['POST'])
 def forum_reply(topic_id):
     author = request.form['author']
     content = request.form['content']
     forum_db.create_post(topic_id, author, content)
-    return redirect(f'/forum/{topic_id}')
+    return redirect(url_for('forum_topic_view', topic_id=topic_id))
 
 @app.route('/forum/vote-topic', methods=['POST'])
 def vote_topic():

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -16,7 +16,7 @@
 <div class="topic-list">
   {% for topic in topics %}
   <div class="topic-card">
-    <h3>{{ topic.title }}</h3>
+    <h3><a href="{{ url_for('forum_topic_view', topic_id=topic.id) }}">{{ topic.title }}</a></h3>
     <p>{{ topic.body or topic.description }}</p>
     <div class="post-actions">
       <button class="action-btn like">👍 <span>{{ topic.likes }}</span></button>

--- a/templates/forum_topic_view.html
+++ b/templates/forum_topic_view.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ topic.title if topic else 'Tema no encontrado' }}{% endblock %}
+
+{% block content %}
+  {% if topic %}
+  <div class="forum-topic-container">
+    <button onclick="window.location.href='{{ url_for('forum_index') }}'" class="back-btn">← Volver al foro</button>
+    <h1 class="topic-title">{{ topic.title }}</h1>
+    <p class="topic-meta">Categoría: {{ topic.category }} • {{ topic.created_at.strftime('%d %b %Y, %H:%M') }}</p>
+    <div class="topic-body">{{ topic.description }}</div>
+    <hr/>
+    <h2 class="responses-title">Respuestas</h2>
+    {% for r in responses %}
+      <div class="response-card">
+        <p class="response-body">{{ r.content or r.body }}</p>
+        <p class="response-meta">por {{ r.author }} • {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</p>
+      </div>
+    {% else %}
+      <p class="no-resp">Sé el primero en responder este tema.</p>
+    {% endfor %}
+    <form class="reply-form" action="{{ url_for('forum_reply', topic_id=topic.id) }}" method="post">
+      <label for="author">Nombre</label>
+      <input id="author" name="author" type="text" required>
+      <label for="content">Respuesta</label>
+      <textarea id="content" name="content" required></textarea>
+      <button type="submit" class="reply-btn">Enviar respuesta</button>
+    </form>
+  </div>
+  {% else %}
+  <div class="alert alert-warning">
+    No encontramos ese tema. <a href="{{ url_for('forum_index') }}">Volver al foro</a>
+  </div>
+  {% endif %}
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -47,9 +47,9 @@
 
   <section id="latest-topic">
     {% if latest %}
-      <h3><a href="/forum/{{ latest.id }}">{{ latest.title }}</a></h3>
+      <h3><a href="/forum/tema/{{ latest.id }}">{{ latest.title }}</a></h3>
       <p>{{ latest.description[:300] }}{% if latest.description and latest.description|length > 300 %}...{% endif %}</p>
-      <a href="/forum/{{ latest.id }}" class="read-more">Leer más →</a>
+      <a href="/forum/tema/{{ latest.id }}" class="read-more">Leer más →</a>
       <p class="date">{{ latest.created_at }}</p>
     {% endif %}
   </section>


### PR DESCRIPTION
## Summary
- add `/forum/tema/<id>` page to display a topic
- show reply form in the topic page and redirect there after posting
- link topics from home and index to new route
- append collaborative line to README story

## Testing
- `python -m py_compile app.py modules/forum.py`

------
https://chatgpt.com/codex/tasks/task_e_6873020efb108325beffefe4a8de54d0