### PR TITLE
Agrega sistema de respuestas y votaciones al foro

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ El eco de nuestro ingenio se entrelaza con el viento de nuevas ideas.
 Las mareas de la comunidad empujan a la bestia a horizontes insondables.
 Su latido colectivo guía el rumbo hacia nuevas evoluciones.
 Cada grieta del desierto digital revela nuevos brotes de colaboración.
+✨ Se agregaron respuestas, votos y sistema de creación de respuestas al foro (🎉 tablas responses y votes).

--- a/static/style.css
+++ b/static/style.css
@@ -724,10 +724,23 @@ body.forum-new {
   margin-bottom: 1.5rem;
 }
 .response-card {
-  background: #222;
-  border-radius: 0.75rem;
-  padding: 1.5rem;
+  background: #111;
+  padding: 1rem;
   margin-bottom: 1rem;
+  border-radius: .5rem;
+  animation: fadeIn 0.3s ease-out;
+}
+.response-card .voting button {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+.response-card .voting button:hover { transform: scale(1.1); }
+.response-card .voting .score {
+  margin: 0 .5rem;
+  font-weight: 700;
 }
 .responses-title {
   font-size: 1.5rem;
@@ -787,7 +800,10 @@ body.forum-new {
 .reply-meta { font-size:0.8rem; color:#aaa; }
 .reply-form textarea { width:100%; background:#222; color:#eee; border-radius:.5rem; border:1px solid #444; padding:.5rem; }
 .reply-form button { margin-top:.5rem; }
-@keyframes fadeIn { from {opacity:0;} to {opacity:1;} }
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 .topic-detail-card, .reply-card { transition: background 0.3s ease, transform 0.2s ease; }
 .topic-detail-card:hover, .reply-card:hover { transform: translateY(-3px); background: #222; }
 .btn-primary { background: #6b63ff; color: #fff; }

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -12,14 +12,24 @@
     <hr/>
     <h2 class="responses-title">Respuestas</h2>
     {% for r in responses %}
-      <div class="response-card">
-        <p class="response-body">{{ r.content or r.body }}</p>
-        <p class="response-meta">por {{ r.author }} • {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</p>
+    <div class="response-card">
+      <div class="meta">{{ r.author }} • {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</div>
+      <p class="content">{{ r.content }}</p>
+      <div class="voting">
+        <form action="{{ url_for('vote_response', response_id=r.id) }}" method="post">
+          <button name="delta" value="1">👍</button>
+          <span class="score">{{ r.score }}</span>
+          <button name="delta" value="-1">👎</button>
+        </form>
       </div>
+    </div>
     {% else %}
-      <p class="no-resp">Sé el primero en responder este tema.</p>
+    <p class="no-resp">No hay respuestas aún. Sé el primero en responder:</p>
     {% endfor %}
-    <a href="{{ url_for('forum_new') }}" class="reply-btn">Añadir respuesta</a>
+    <form action="{{ url_for('create_response', topic_id=topic.id) }}" method="post">
+      <textarea name="content" required placeholder="Tu respuesta…"></textarea>
+      <button type="submit">Responder</button>
+    </form>
   </div>
   {% else %}
   <div class="alert alert-warning">


### PR DESCRIPTION
## Cambios principales
- Creación asegurada de tablas `responses` y `votes` al iniciar la app
- Funciones en `modules/forum.py` para manejar respuestas, votos y puntuaciones
- Nuevas rutas en Flask para crear respuestas y votar
- Vista de tema actualizada mostrando respuestas con su puntuación
- Estilos y animaciones para tarjetas de respuesta
- Línea añadida al README resaltando la nueva funcionalidad

------
https://chatgpt.com/codex/tasks/task_e_68730ffffb04832586a4532afd4e3efb