### PR TITLE
Add 404 page and extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,4 @@ Su latido colectivo guía el rumbo hacia nuevas evoluciones.
 Cada grieta del desierto digital revela nuevos brotes de colaboración.
 ✨ Se agregaron respuestas, votos y sistema de creación de respuestas al foro (🎉 tablas responses y votes).
 Susurros digitales despiertan la curiosidad de nuevas almas viajeras.
+La bestia sigue dejando huellas que guían a quienes buscan claridad.

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block title %}404 - No encontrado{% endblock %}
+
+{% block content %}
+  <div class="forum-topic-container">
+    <h1 class="topic-title">404</h1>
+    <p class="topic-meta">No encontramos lo que buscas.</p>
+    <a href="{{ url_for('home') }}" class="back-btn">Volver al inicio</a>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add missing `404.html` template so invalid forum pages show a styled message
- extend the README story with a new line

## Testing
- `python -m py_compile app.py modules/forum.py`

------
https://chatgpt.com/codex/tasks/task_e_6873147c56808325a2c1ccab70559535