### PR TITLE
Fix forum response datetime parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ Cada grieta del desierto digital revela nuevos brotes de colaboración.
 ✨ Se agregaron respuestas, votos y sistema de creación de respuestas al foro (🎉 tablas responses y votes).
 Susurros digitales despiertan la curiosidad de nuevas almas viajeras.
 La bestia sigue dejando huellas que guían a quienes buscan claridad.
+Nuevas sendas se revelan entre la arena, guiando a los caminantes digitales.

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -234,11 +234,16 @@ def get_responses_for_topic(topic_id: int) -> List[Dict]:
         # Si la tabla no existe, capturamos y devolvemos lista vacía
         cur.execute(
             "SELECT id, author, content, created_at FROM responses WHERE topic_id = ? ORDER BY created_at ASC",
-            (topic_id,)
+            (topic_id,),
         )
         rows = cur.fetchall()
         return [
-            {"id": r[0], "author": r[1], "content": r[2], "created_at": r[3]}
+            {
+                "id": r[0],
+                "author": r[1],
+                "content": r[2],
+                "created_at": _parse_datetime(r[3]),
+            }
             for r in rows
         ]
     except Exception as e:


### PR DESCRIPTION
## Summary
- fix 500 error when viewing forum responses by parsing timestamp values
- extend README story

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687316a06a288325a871759edd55a22e