### PR TITLE
Corrección: Esquema de Respuestas y Endpoints de Foro

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Cada grieta del desierto digital revela nuevos brotes de colaboración.
 Susurros digitales despiertan la curiosidad de nuevas almas viajeras.
 La bestia sigue dejando huellas que guían a quienes buscan claridad.
 Nuevas sendas se revelan entre la arena, guiando a los caminantes digitales.
+Las estrellas testimonian la expansion constante de la bestia.

--- a/app.py
+++ b/app.py
@@ -235,28 +235,6 @@ def forum_new():
         return redirect(url_for('forum_topic_view', topic_id=topic_id))
     return render_template('forum_new.html', categories=forum_db.get_categories())
 
-@app.route('/forum/<int:topic_id>')
-def forum_topic(topic_id):
-    try:
-        topic = get_topic_by_id(topic_id)
-        if topic is None:
-            flash("\u26a0\ufe0f Tema no encontrado.", "warning")
-            return redirect(url_for('forum_index'))
-        responses = get_responses_for_topic(topic_id)
-    except Exception:
-        flash("No se pudo cargar el tema, intenta más tarde", "danger")
-        return redirect(url_for('forum_index'))
-
-    show_delete = False
-    if session.get('user') and request.args.get('password') == 'borrar1':
-        show_delete = True
-
-    return render_template(
-        'forum_detail.html',
-        topic=topic,
-        responses=responses,
-        show_delete=show_delete,
-    )
 
 @app.route('/forum/tema/<int:topic_id>')
 def forum_topic_view(topic_id):
@@ -272,7 +250,7 @@ def forum_reply(topic_id):
     author = request.form['author']
     content = request.form['content']
     forum_db.create_post(topic_id, author, content)
-    return redirect(url_for('forum_topic', topic_id=topic_id))
+    return redirect(url_for('forum_topic_view', topic_id=topic_id))
 
 
 @app.route('/forum/<int:topic_id>/response', methods=['POST'])


### PR DESCRIPTION
## Summary
- ensure `responses` table exists when connecting to DB
- handle missing `responses` table gracefully
- remove old forum topic route and centralize at `/forum/tema/<id>`
- fix redirects after posting
- extend EEVI story in README

## Testing
- `python -m py_compile app.py modules/forum.py`

------
https://chatgpt.com/codex/tasks/task_e_687319d008ac83258bd1db96295bffc2