### PR TITLE
Implementa ruta catch-all para páginas dinámicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,6 @@ Susurros digitales despiertan la curiosidad de nuevas almas viajeras.
 La bestia sigue dejando huellas que guían a quienes buscan claridad.
 Nuevas sendas se revelan entre la arena, guiando a los caminantes digitales.
 Las estrellas testimonian la expansion constante de la bestia.
+Sus ecos digitales inspiran rutas inexploradas en la vastedad del ciberdesierto.
+
+🔗 Ahora EEVI puede servir cualquier template estático añadiendo <page>.html en la carpeta templates sin modificar rutas de Flask.

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
-from flask import Flask, render_template, request, redirect, jsonify, url_for, session, flash
+from flask import Flask, render_template, request, redirect, jsonify, url_for, session, flash, abort
 import json
 import os
 import sqlite3
+from jinja2 import TemplateNotFound
 
 DB_PATH = 'db/forum.db'
 
@@ -285,6 +286,16 @@ def delete_topic(id):
     if request.form.get('password') == 'borrar1':
         forum_db.delete_topic_by_id(id)
     return redirect(url_for('forum_index'))
+
+from flask import abort, render_template
+from jinja2 import TemplateNotFound
+
+@app.route('/<page>')
+def render_page(page):
+    try:
+        return render_template(f"{page}.html")
+    except TemplateNotFound:
+        abort(404)
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Añade función render_page(page) que intenta servir <page>.html o devuelve 404.

Importa abort, render_template y TemplateNotFound.

Permite agregar páginas nuevas subiendo el HTML, sin tocar app.py.

------
https://chatgpt.com/codex/tasks/task_e_68731c17c7f08325985e9d10d17c0ccb