### PR TITLE
Enable topic slugs for new forum pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ Las estrellas testimonian la expansion constante de la bestia.
 Sus ecos digitales inspiran rutas inexploradas en la vastedad del ciberdesierto.
 
 🔗 Ahora EEVI puede servir cualquier template estático añadiendo <page>.html en la carpeta templates sin modificar rutas de Flask.
+Cada nuevo enlace es un paso más profundo en el infinito desierto digital.

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -16,7 +16,7 @@
 <div class="topic-list">
   {% for topic in topics %}
   <div class="topic-card">
-    <h3><a href="{{ url_for('forum_topic_view', topic_id=topic.id) }}">{{ topic.title }}</a></h3>
+    <h3><a href="{{ url_for('forum_topic_view', topic_slug=topic.slug) }}">{{ topic.title }}</a></h3>
     <p class="topic-meta">{{ topic.category or 'Sin categoría' }} • {{ topic.created_at }} • {{ topic.author or 'Anónimo' }}</p>
     <p>{{ topic.description }}</p>
   </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -47,9 +47,9 @@
 
   <section id="latest-topic">
     {% if latest %}
-      <h3><a href="/forum/tema/{{ latest.id }}">{{ latest.title }}</a></h3>
+      <h3><a href="/forum/tema/{{ latest.slug }}">{{ latest.title }}</a></h3>
       <p>{{ latest.description[:300] }}{% if latest.description and latest.description|length > 300 %}...{% endif %}</p>
-      <a href="/forum/tema/{{ latest.id }}" class="read-more">Leer más →</a>
+      <a href="/forum/tema/{{ latest.slug }}" class="read-more">Leer más →</a>
       <p class="date">{{ latest.created_at }}</p>
     {% endif %}
   </section>


### PR DESCRIPTION
## Summary
- add slug utilities and queries to forum module
- update DB initialization to include slug column
- route forum topics using slugs and redirect old numeric URLs
- adjust forms and redirects to use slug URLs
- link to topics by slug in templates
- extend README story

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68731d8f2a148325ba4020ed2bef8a1a