### PR TITLE
Añade autor de respuestas y estiliza campo de texto en foro

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ Sus ecos digitales inspiran rutas inexploradas en la vastedad del ciberdesierto.
 
 🔗 Ahora EEVI puede servir cualquier template estático añadiendo <page>.html en la carpeta templates sin modificar rutas de Flask.
 Cada nuevo enlace es un paso más profundo en el infinito desierto digital.
+La travesía recién comienza, guardando la esencia de cada encuentro digital.

--- a/app.py
+++ b/app.py
@@ -229,12 +229,13 @@ def forum_new():
 @app.route('/forum/tema/<int:topic_id>', methods=['GET', 'POST'])
 def forum_topic_view(topic_id):
     if request.method == 'POST':
+        author = request.form['author']
         content = request.form['response']
         conn = sqlite3.connect(DB_PATH)
         cur = conn.cursor()
         cur.execute(
-            "INSERT INTO responses (topic_id, content) VALUES (?, ?)",
-            (topic_id, content)
+            "INSERT INTO responses (topic_id, author, content) VALUES (?, ?, ?)",
+            (topic_id, author, content)
         )
         conn.commit()
         conn.close()

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -12,9 +12,10 @@ def init_db():
     cur = conn.cursor()
     cur.execute(
         """
-          CREATE TABLE IF NOT EXISTS responses (
+        CREATE TABLE IF NOT EXISTS responses (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             topic_id INTEGER NOT NULL,
+            author TEXT NOT NULL,
             content TEXT NOT NULL,
             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY(topic_id) REFERENCES topics(id)
@@ -32,6 +33,7 @@ def get_db():
         CREATE TABLE IF NOT EXISTS responses (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           topic_id INTEGER NOT NULL,
+          author TEXT NOT NULL,
           content TEXT NOT NULL,
           created_at TEXT NOT NULL
         );
@@ -283,7 +285,7 @@ def get_responses_for_topic(topic_id):
     cur = conn.cursor()
     try:
         cur.execute(
-            "SELECT id, content, created_at FROM responses WHERE topic_id = ? ORDER BY created_at",
+            "SELECT id, author, content, created_at FROM responses WHERE topic_id = ? ORDER BY created_at",
             (topic_id,),
         )
         rows = cur.fetchall()

--- a/static/style.css
+++ b/static/style.css
@@ -809,3 +809,27 @@ body.forum-new {
 .btn-primary { background: #6b63ff; color: #fff; }
 .btn-secondary { border: 2px solid #6b63ff; color: #6b63ff; background: transparent; }
 .btn-secondary:hover { background: #6b63ff; color: #000; }
+
+.input-author,
+.response-input {
+  width: 100%;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 1rem;
+  transition: border-color 0.3s ease;
+}
+.input-author:focus,
+.response-input:focus {
+  outline: none;
+  border-color: #6b63ff;
+}
+.response-author {
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  color: #bbb;
+  font-style: italic;
+}

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -11,16 +11,21 @@
     <div class="topic-body">{{ topic.description }}</div>
     <hr/>
     <h2 class="responses-title">Respuestas</h2>
-    {% for r in responses %}
+    {% for response in responses %}
     <div class="response-card">
-      <p class="content">{{ r[1] }}</p>
-      <p class="meta">{{ r[2] }}</p>
+      <div class="response-author">Escrito por: {{ response[1] }}</div>
+      <p class="content">{{ response[2] }}</p>
+      <p class="meta">{{ response[3] }}</p>
     </div>
     {% else %}
     <p class="no-resp">No hay respuestas aún. Sé el primero en responder:</p>
     {% endfor %}
     <form action="{{ url_for('forum_topic_view', topic_id=topic.id) }}" method="post">
-      <textarea name="response" required placeholder="Tu respuesta…"></textarea>
+      <div class="form-group">
+        <label for="author">Tu nombre</label>
+        <input id="author" name="author" type="text" required class="input-author" placeholder="Tu nombre…">
+      </div>
+      <textarea name="response" required class="response-input" placeholder="Tu respuesta…"></textarea>
       <button type="submit">Responder</button>
     </form>
   </div>


### PR DESCRIPTION
## Resumen
- agregada columna `author` en inicialización de `responses`
- guardado de autor al crear respuestas en `app.py`
- mostrado del autor en cada respuesta de `forum_topic.html`
- formulario de respuesta ahora pide el nombre del autor
- nuevos estilos para `input-author` y `response-input`
- línea narrativa añadida al README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68732bb6e3608325940b6ec07509f330