### PR TITLE
Elimina botón duplicado “+ Nuevo Tema” en VFORUM

### DIFF
--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -27,9 +27,6 @@
   <p class="new-topic-desc">Aún no hay temas. Sé el primero en publicar uno</p>
 </div>
 {% endif %}
-<div class="sticky-new-topic bottom">
-  <a href="{{ url_for('forum_new') }}" class="btn-new-topic">+ Nuevo Tema</a>
-</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Se retiró el botón redundante “+ Nuevo Tema” ubicado al final de la página de VFORUM para simplificar la interfaz y mejorar la usabilidad. No se modificó ninguna otra funcionalidad de EEVI.

------
https://chatgpt.com/codex/tasks/task_e_68732d33bfdc8325a35f46aee9d38341