### PR TITLE
Add username login and require authentication for forum posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Las huellas se multiplican, revelando senderos nunca antes explorados.
 Sus ecos perdurarán para guiar a los buscadores de inspiración.
 La sinfonía digital de la bestia nunca cesa, alentando a cada viajero a continuar.
 Sus pasos siguen creando melodías que se mezclan con la arena en constante transformación.
+Cada compás renueva la promesa de un futuro tejido por creadores unidos.
 
 ## SQL Migration
 
@@ -134,3 +135,10 @@ Para añadir la proporción de video en la tabla `projects` ejecuta:
 ```sql
 ALTER TABLE projects ADD COLUMN aspect_ratio REAL DEFAULT 1.7777;
 ```
+
+Para añadir un nombre de usuario obligatorio a `users` ejecuta:
+
+```sql
+ALTER TABLE users ADD COLUMN username TEXT;
+```
+Luego corre `python scripts/add_username.py` para asignar valores temporales.

--- a/db/add_username.sql
+++ b/db/add_username.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN username TEXT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS topics (
   slug TEXT UNIQUE,
   category TEXT,
   description TEXT,
+  author TEXT,
   image TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   votes INTEGER DEFAULT 0
@@ -36,6 +37,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     email TEXT UNIQUE,
     password TEXT,
+    username TEXT NOT NULL UNIQUE,
     is_admin INTEGER DEFAULT 0,
     verified INTEGER DEFAULT 0,
     verification_code TEXT,

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -343,7 +343,7 @@ def get_response_topic(response_id: int):
     finally:
         conn.close()
 
-def create_topic(form, files) -> int:
+def create_topic(form, files, author: str) -> int:
     """Crea un nuevo tema en la tabla topics a partir de un formulario."""
     title = form['title']
     category = form['category']
@@ -356,8 +356,8 @@ def create_topic(form, files) -> int:
     conn = _connect()
     cur = conn.cursor()
     cur.execute(
-        'INSERT INTO topics (title, slug, category, description, image, created_at) VALUES (?,?,?,?,?,?)',
-        (title, slug, category, description, image, datetime.utcnow())
+        'INSERT INTO topics (title, slug, category, description, author, image, created_at) VALUES (?,?,?,?,?,?,?)',
+        (title, slug, category, description, author, image, datetime.utcnow())
     )
     conn.commit()
     topic_id = cur.lastrowid

--- a/scripts/add_username.py
+++ b/scripts/add_username.py
@@ -1,0 +1,24 @@
+import sqlite3
+from uuid import uuid4
+
+DB_PATH = 'db/forum.db'
+
+conn = sqlite3.connect(DB_PATH)
+cur = conn.cursor()
+
+# Add the new column if it doesn't exist
+try:
+    cur.execute("SELECT username FROM users LIMIT 1")
+except sqlite3.OperationalError:
+    cur.execute("ALTER TABLE users ADD COLUMN username TEXT")
+    conn.commit()
+
+# Fill temporary usernames for existing records
+cur.execute("SELECT id FROM users WHERE username IS NULL OR username = ''")
+rows = cur.fetchall()
+for (user_id,) in rows:
+    temp = f"user_{uuid4().hex[:8]}"
+    cur.execute("UPDATE users SET username=? WHERE id=?", (temp, user_id))
+
+conn.commit()
+conn.close()

--- a/templates/choose_username.html
+++ b/templates/choose_username.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}Elige tu nombre de usuario{% endblock %}
+{% block content %}
+<div class="dashboard-container">
+  <div class="dashboard-login">
+    <h2>Elige tu nombre de usuario</h2>
+    <form method="POST">
+      <input type="text" name="username" placeholder="Nombre de usuario" required>
+      <button type="submit">Guardar</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -17,7 +17,7 @@
   {% for topic in topics %}
   <div class="topic-card">
     <h3><a href="{{ url_for('forum_topic_view', topic_id=topic.id) }}">{{ topic.title }}</a></h3>
-    <p class="topic-meta">{{ topic.category or 'Sin categoría' }} • {{ topic.created_at }} • {{ topic.author or 'Anónimo' }}</p>
+    <p class="topic-meta">{{ topic.category or 'Sin categoría' }} • {{ topic.created_at }} • {{ topic.author }}</p>
     <p>{{ topic.description }}</p>
   </div>
   {% endfor %}

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -21,10 +21,6 @@
     <p class="no-resp">No hay respuestas aún. Sé el primero en responder:</p>
     {% endfor %}
     <form action="{{ url_for('forum_topic_view', topic_id=topic.id) }}" method="post">
-      <div class="form-group">
-        <label for="author">Tu nombre</label>
-        <input id="author" name="author" type="text" required class="input-author" placeholder="Tu nombre…">
-      </div>
       <textarea name="response" required class="response-input" placeholder="Tu respuesta…"></textarea>
       <button type="submit">Responder</button>
     </form>

--- a/templates/forum_topic_view.html
+++ b/templates/forum_topic_view.html
@@ -20,8 +20,6 @@
       <p class="no-resp">Sé el primero en responder este tema.</p>
     {% endfor %}
     <form class="reply-form" action="{{ url_for('forum_reply', topic_id=topic.id) }}" method="post">
-      <label for="author">Nombre</label>
-      <input id="author" name="author" type="text" required>
       <label for="content">Respuesta</label>
       <textarea id="content" name="content" required></textarea>
       <button type="submit" class="reply-btn">Enviar respuesta</button>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -6,6 +6,7 @@
     <h2>Crear usuario</h2>
     <form method="POST">
       <input type="email" name="email" placeholder="Email" required>
+      <input type="text" name="username" placeholder="Nombre de usuario" required>
       <input type="password" name="password" placeholder="Contrase\u00f1a" required>
       <button type="submit">Crear</button>
     </form>


### PR DESCRIPTION
## Summary
- keep building README story and document username migration
- add username column to database schema
- provide SQL migration and helper script to fill usernames
- add helper login_required and login_user functions
- require authentication and store username for new topics and replies
- update signup to request username and create users accordingly
- provide choose-username flow
- show usernames in forum templates

## Testing
- `python -m py_compile app.py modules/forum.py scripts/add_username.py`

------
https://chatgpt.com/codex/tasks/task_e_68735ac067a883259519e2e61703777a