### PR TITLE
Fix projects client_id migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ La sinfonía digital de la bestia nunca cesa, alentando a cada viajero a continu
 Sus pasos siguen creando melodías que se mezclan con la arena en constante transformación.
 Cada compás renueva la promesa de un futuro tejido por creadores unidos.
 Su sombra se extiende más allá del horizonte, señalando rutas aún por descubrir.
+Las dunas vibran con la expectación de los retos venideros.
 
 ## SQL Migration
 

--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ def ensure_projects_schema(cursor):
         "category": "TEXT",
         "video_url": "TEXT",
         "client_email": "TEXT",
+        "client_id": "INTEGER DEFAULT NULL",
         "active": "INTEGER DEFAULT 0",
         "paid": "INTEGER DEFAULT 0",
         "progress": "REAL DEFAULT 0",
@@ -86,6 +87,12 @@ def init_db():
     schema_path = os.path.join(os.path.dirname(__file__), "db", "schema.sql")
     with open(schema_path, "r", encoding="utf-8") as f:
         cursor.executescript(f.read())
+
+    # Run migration for client_id if column is missing
+    cursor.execute("PRAGMA table_info(projects)")
+    cols = [r[1] for r in cursor.fetchall()]
+    if "client_id" not in cols:
+        cursor.executescript("ALTER TABLE projects ADD COLUMN client_id INTEGER DEFAULT NULL;")
 
     # Ensure slug column exists for older databases
     try:

--- a/db/migrations.sql
+++ b/db/migrations.sql
@@ -1,7 +1,7 @@
 -- Migration for new project management features
 
 -- Add columns to projects
-ALTER TABLE projects ADD COLUMN client_id INTEGER;
+ALTER TABLE projects ADD COLUMN client_id INTEGER DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN status TEXT CHECK(status IN ('draft','active','closed','archived')) DEFAULT 'draft';
 ALTER TABLE projects ADD COLUMN payment_validated INTEGER DEFAULT 0;
 ALTER TABLE projects ADD COLUMN payment_code VARCHAR(100);


### PR DESCRIPTION
## Summary
- add `client_id` migration
- update DB initialization to ensure the column exists
- keep schema helper in sync
- extend README story

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models')*
- `pip install -r requirements.txt` *(failed to install dependencies: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873696cc1ec8325a7072b5ff51cb2f5