### PR TITLE
Add SQLAlchemy models and migrations setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.sqlite3
 *.log
 logs/
+migrations/

--- a/app.py
+++ b/app.py
@@ -19,6 +19,8 @@ import uuid
 from jinja2 import TemplateNotFound
 
 from config import DevelopmentConfig, ProductionConfig, TestingConfig
+from models import db
+from flask_migrate import Migrate
 
 app = Flask(__name__)
 
@@ -29,6 +31,9 @@ config_map = {
     "testing": TestingConfig,
 }
 app.config.from_object(config_map.get(env, DevelopmentConfig))
+
+db.init_app(app)
+migrate = Migrate(app, db)
 
 
 def get_db():

--- a/config.py
+++ b/config.py
@@ -3,6 +3,8 @@ class BaseConfig:
     SECRET_KEY = 'demo-secret-key'
     DEBUG = False
     ENV = 'production'
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{DB_PATH}"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 class DevelopmentConfig(BaseConfig):
     DEBUG = True

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,6 @@
+from .base import db
+from .user import User
+from .project import Project
+from .comment import Comment
+
+__all__ = ["db", "User", "Project", "Comment"]

--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/models/comment.py
+++ b/models/comment.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from .base import db
+from .user import User, TimestampMixin
+from .project import Project
+
+
+class Comment(db.Model, TimestampMixin):
+    __tablename__ = 'comment'
+
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.Text, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    project_id = db.Column(db.Integer, db.ForeignKey('project.id'))
+
+    user = db.relationship(User, backref=db.backref('comments', lazy=True))
+    project = db.relationship(Project, backref=db.backref('comments', lazy=True))

--- a/models/project.py
+++ b/models/project.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from .base import db
+from .user import User, TimestampMixin
+
+
+class Project(db.Model, TimestampMixin):
+    __tablename__ = 'project'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    user = db.relationship(User, backref=db.backref('projects', lazy=True))

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from .base import db
+
+
+class TimestampMixin:
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class User(db.Model, TimestampMixin):
+    __tablename__ = 'user'
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask==2.3.3
+Flask-SQLAlchemy==3.0.5
+Flask-Migrate==4.0.4
 gunicorn==21.2.0

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+flask db init && flask db migrate -m "initial" && flask db upgrade
+


### PR DESCRIPTION
## Summary
- integrate SQLAlchemy and Migrate
- add User, Project and Comment models
- ignore generated migrations
- provide helper script to run migrations
- update dependencies

## Testing
- `./scripts/db_migrate.sh` *(fails: flask not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f49b3cdc832580ddb536a8e186ea