### PR TITLE
Add project comment system

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -62,3 +62,13 @@ CREATE TABLE IF NOT EXISTS projects (
     download TEXT,
     FOREIGN KEY(client_id) REFERENCES clients(id)
 );
+
+CREATE TABLE IF NOT EXISTS comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(project_id) REFERENCES projects(id),
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -28,4 +28,37 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('theme-toggle')?.addEventListener('click', () => {
     document.body.classList.toggle('light-mode');
   });
+
+  document.querySelectorAll('.comments').forEach(container => {
+    const projectId = container.dataset.project;
+    const listEl = container.querySelector('.comments-list');
+    const form = container.querySelector('.comment-form');
+
+    const loadComments = () => {
+      fetch(`/project/${projectId}/comments`)
+        .then(r => r.json())
+        .then(data => {
+          listEl.innerHTML = '';
+          data.forEach(c => {
+            const div = document.createElement('div');
+            div.className = 'comment';
+            div.innerHTML = `<strong>${c.user}</strong>: ${c.text} <span class="date">${c.date}</span>`;
+            listEl.appendChild(div);
+          });
+        });
+    };
+
+    loadComments();
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const formData = new FormData(form);
+      fetch(`/project/${projectId}/comments`, {
+        method: 'POST',
+        body: formData
+      }).then(() => {
+        form.reset();
+        loadComments();
+      });
+    });
+  });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -836,3 +836,12 @@ body.forum-new {
 
 .btn{background:#6b63ff;color:#fff;padding:0.5rem 1rem;text-decoration:none;border:none;display:inline-block;margin:0.5rem;}
 
+.comments{margin-top:1rem;}
+.comments-list{margin-bottom:0.5rem;}
+.comment{border-bottom:1px solid #444;padding:0.25rem 0;}
+.comment .date{margin-left:0.5rem;font-size:0.8rem;color:#999;}
+.comment-form{display:flex;gap:0.5rem;}
+.comment-form input{flex:1;}
+.comments-admin{list-style:none;padding:0;margin:1rem 0;}
+.comments-admin li{padding:0.25rem 0;border-bottom:1px solid #444;}
+

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -39,6 +39,12 @@
     </div>
     {% endfor %}
   </div>
+  <h3>Comentarios recientes</h3>
+  <ul class="comments-admin">
+    {% for c in comments %}
+    <li><strong>{{ c.user_email }}</strong> en <em>{{ c.project }}</em>: {{ c.text }} <span class="date">{{ c.date }}</span></li>
+    {% endfor %}
+  </ul>
 </div>
 {% endblock %}
 {% block scripts %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,6 +41,13 @@
         style="width:100%;height:400px;"
       ></iframe>
       {% if not p.paid %}<button class="pay-btn">Pagar 50% restante</button>{% endif %}
+      <div class="comments" data-project="{{ p.id }}">
+        <div class="comments-list"></div>
+        <form class="comment-form">
+          <input type="text" name="text" placeholder="Nuevo comentario" required>
+          <button type="submit">Enviar</button>
+        </form>
+      </div>
     </div>
     {% endfor %}
   </div>

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,24 @@
+import app
+import sqlite3
+import modules.forum as forum_db
+
+
+def setup_db(tmp_path):
+    db_file = tmp_path / "test.db"
+    app.app.config['DB_PATH'] = str(db_file)
+    forum_db.DB_PATH = str(db_file)
+    app.init_db()
+    forum_db.init_db()
+    return db_file
+
+
+def test_add_comment(tmp_path):
+    setup_db(tmp_path)
+    app.create_user('c@e.com', 'p')
+    app.add_project('T', 'c', '', 'c@e.com')
+    proj = app.get_projects_for_email('c@e.com')[0]
+    user = app.get_user('c@e.com')
+    app.add_comment(proj['id'], user['id'], 'hola')
+    comments = app.get_comments(proj['id'])
+    assert len(comments) == 1
+    assert comments[0]['text'] == 'hola'


### PR DESCRIPTION
## Summary
- create `comments` table
- support adding and querying project comments
- expose `/project/<id>/comments` route
- show comments in client dashboard and admin dashboard
- add styles and JS for comment interactions
- test DB comment helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6873f743ac888325b8f2970319a1f4bc