### PR TITLE
Fix blueprint endpoints after refactor

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,7 +156,7 @@ def forum_index():
         topics = forum_db.get_topics()
     except Exception:
         flash("Error al cargar el foro, inténtalo más tarde", "danger")
-        return redirect(url_for('client_bp.home'))
+        return redirect(url_for('client.home'))
 
     return render_template(
         'forum_index.html',

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -43,7 +43,7 @@ def admin_signup():
         email = request.form['email']
         password = request.form['password']
         create_user(email, password, True)
-        return redirect(url_for('client_bp.verify', email=email))
+        return redirect(url_for('client.verify', email=email))
     return render_template('admin_signup.html')
 
 

--- a/routes/client.py
+++ b/routes/client.py
@@ -5,7 +5,7 @@ from services.comment_manager import CommentManager
 from utils.security import login_required
 from utils.validators import is_valid_url
 
-client_bp = Blueprint('client_bp', __name__)
+client_bp = Blueprint('client', __name__)
 
 
 def _projects():
@@ -93,7 +93,7 @@ def dashboard_login():
         from app import check_password
         if check_password(email, password):
             session['user'] = email
-            return redirect(url_for('client_bp.dashboard'))
+            return redirect(url_for('client.dashboard'))
     return render_template('dashboard_login.html')
 
 
@@ -104,7 +104,7 @@ def signup():
         password = request.form['password']
         from app import create_user
         create_user(email, password)
-        return redirect(url_for('client_bp.verify', email=email))
+        return redirect(url_for('client.verify', email=email))
     return render_template('signup.html')
 
 
@@ -121,7 +121,7 @@ def verify():
         if row and row[0] == code:
             cur.execute('UPDATE users SET verified=1 WHERE email=?', (email,))
             conn.commit()
-            return redirect(url_for('client_bp.dashboard_login'))
+            return redirect(url_for('client.dashboard_login'))
         abort(401)
     return render_template('verify.html', email=email)
 
@@ -136,14 +136,14 @@ def upload_profile():
         file.save(path)
         from app import save_profile_pic
         save_profile_pic(user_email, '/' + path)
-    return redirect(url_for('client_bp.dashboard'))
+    return redirect(url_for('client.dashboard'))
 
 
 @client_bp.route('/dashboard/logout', methods=['POST'])
 @login_required
 def logout():
     session.pop('user', None)
-    return redirect(url_for('client_bp.dashboard'))
+    return redirect(url_for('client.dashboard'))
 
 
 @client_bp.route('/project/<int:project_id>/comments', methods=['GET', 'POST'])

--- a/templates/404.html
+++ b/templates/404.html
@@ -6,6 +6,6 @@
   <div class="forum-topic-container">
     <h1 class="topic-title">404</h1>
     <p class="topic-meta">No encontramos lo que buscas.</p>
-    <a href="{{ url_for('home') }}" class="back-btn">Volver al inicio</a>
+    <a href="{{ url_for('client.home') }}" class="back-btn">Volver al inicio</a>
   </div>
 {% endblock %}

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,12 +1,12 @@
 <header class="header">
-  <a href="{{ url_for('home') }}" class="logo">VERITÉ</a>
+  <a href="{{ url_for('client.home') }}" class="logo">VERITÉ</a>
   <nav class="nav">
-    <a href="{{ url_for('home') }}" class="nav-link">INICIO</a>
-    <a href="{{ url_for('packs') }}" class="nav-link">PACKS</a>
-    <a href="{{ url_for('services') }}" class="nav-link">SERVICES</a>
+    <a href="{{ url_for('client.home') }}" class="nav-link">INICIO</a>
+    <a href="{{ url_for('client.packs') }}" class="nav-link">PACKS</a>
+    <a href="{{ url_for('client.services_page') }}" class="nav-link">SERVICES</a>
     <a href="{{ url_for('forum_index') }}" class="nav-link">VFORUM</a>
-    <a href="{{ url_for('academy') }}" class="nav-link">ACADEMIA</a>
-    <a href="{{ url_for('dashboard') }}" class="nav-link">DASHBOARD</a>
+    <a href="{{ url_for('client.academy') }}" class="nav-link">ACADEMIA</a>
+    <a href="{{ url_for('client.dashboard') }}" class="nav-link">DASHBOARD</a>
     <a href="{{ url_for('admin') }}" class="nav-link">ADMIN</a>
   </nav>
 </header>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,14 +6,14 @@
 <div class="dashboard-container">
   {% if not user %}
   <div class="dashboard-login">
-    <a href="{{ url_for('signup') }}" class="btn">Crear usuario</a>
-    <a href="{{ url_for('dashboard_login') }}" class="btn">Log in</a>
+    <a href="{{ url_for('client.signup') }}" class="btn">Crear usuario</a>
+    <a href="{{ url_for('client.dashboard_login') }}" class="btn">Log in</a>
   </div>
   {% else %}
   <div class="dashboard-header">
     <h2>Bienvenido, {{ user.email }}</h2>
     <button id="theme-toggle">Modo</button>
-    <form action="{{ url_for('logout') }}" method="post" style="display:inline;">
+    <form action="{{ url_for('client.logout') }}" method="post" style="display:inline;">
       <button type="submit">Salir</button>
     </form>
   </div>
@@ -72,7 +72,7 @@
   <div class="profile">
     <h3>Perfil de Usuario</h3>
     <img src="{{ user.profile_pic or '/static/img/pack1.jpg' }}" alt="Foto" class="profile-pic">
-    <form action="{{ url_for('upload_profile') }}" method="post" enctype="multipart/form-data">
+    <form action="{{ url_for('client.upload_profile') }}" method="post" enctype="multipart/form-data">
       <input type="file" name="photo" accept="image/*" required>
       <button type="submit">Actualizar foto</button>
     </form>

--- a/utils/security.py
+++ b/utils/security.py
@@ -6,7 +6,7 @@ def login_required(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         if 'user' not in session:
-            return redirect(url_for('client_bp.dashboard_login'))
+            return redirect(url_for('client.dashboard_login'))
         return f(*args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
## Summary
- define the `client` blueprint so its endpoint prefix is `client.*`
- update all calls to `url_for('home')` and other client routes
- fix references in admin code and security helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6873fe37c8708325985082c5b22d7ddd