### PR TITLE
Fix blueprint endpoint references

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ def create_app():
     migrate.init_app(app, db)
     app.register_blueprint(admin_bp, url_prefix='/admin')
     app.register_blueprint(client_bp)
+    app.add_url_rule('/', endpoint='home', view_func=client_bp.view_functions['home'])
     app.teardown_appcontext(close_db)
 
     with app.app_context():

--- a/routes/client.py
+++ b/routes/client.py
@@ -39,7 +39,7 @@ def get_all_services():
         return json.load(f)
 
 
-@client_bp.route('/')
+@client_bp.route('/', methods=['GET'])
 def home():
     from modules import forum as forum_db
     latest = forum_db.get_latest_topic()

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -7,6 +7,6 @@
     <a href="{{ url_for('forum_index') }}" class="nav-link">VFORUM</a>
     <a href="{{ url_for('client.academy') }}" class="nav-link">ACADEMIA</a>
     <a href="{{ url_for('client.dashboard') }}" class="nav-link">DASHBOARD</a>
-    <a href="{{ url_for('admin') }}" class="nav-link">ADMIN</a>
+    <a href="{{ url_for('admin_bp.admin') }}" class="nav-link">ADMIN</a>
   </nav>
 </header>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -4,12 +4,12 @@
 <div class="dashboard-container">
   <div class="dashboard-header">
     <h2>Panel Admin</h2>
-    <form action="{{ url_for('admin_logout') }}" method="post" style="display:inline;">
+    <form action="{{ url_for('admin_bp.admin_logout') }}" method="post" style="display:inline;">
       <button type="submit">Salir</button>
     </form>
   </div>
   <div class="dashboard-login" style="margin-bottom:1rem;">
-    <form action="{{ url_for('admin_add_project') }}" method="post">
+    <form action="{{ url_for('admin_bp.admin_add_project') }}" method="post">
       <input type="text" name="title" placeholder="Título" required>
       <input type="text" name="category" placeholder="Categoría" required>
       <input type="text" name="video_url" placeholder="URL" required>
@@ -21,19 +21,19 @@
     {% for p in projects %}
     <div class="project-card">
       <h4>{{ p.title }}</h4>
-      <form action="{{ url_for('admin_update_project', project_id=p.id) }}" method="post">
+      <form action="{{ url_for('admin_bp.admin_update_project', project_id=p.id) }}" method="post">
         <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" style="width:100%;margin-bottom:.5rem;">
         <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" style="width:100%;margin-bottom:.5rem;">
         <button type="submit">Guardar</button>
       </form>
-      <form action="{{ url_for('admin_activate_payment', project_id=p.id) }}" method="post" style="margin-top:.5rem;">
+      <form action="{{ url_for('admin_bp.admin_activate_payment', project_id=p.id) }}" method="post" style="margin-top:.5rem;">
         {% if not p.paid %}
         <button type="submit" class="pay-btn">Activar 50%</button>
         {% else %}
         <span>Pago activado</span>
         {% endif %}
       </form>
-      <form action="{{ url_for('admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" style="margin-top:.5rem;">
+      <form action="{{ url_for('admin_bp.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" style="margin-top:.5rem;">
         <button type="submit">Eliminar Video</button>
       </form>
     </div>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="dashboard-container">
   <div class="dashboard-login">
-    <a href="{{ url_for('admin_signup') }}" class="btn">Crear admin</a>
-    <a href="{{ url_for('admin_login') }}" class="btn">Log in</a>
+    <a href="{{ url_for('admin_bp.admin_signup') }}" class="btn">Crear admin</a>
+    <a href="{{ url_for('admin_bp.admin_login') }}" class="btn">Log in</a>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure `home` route uses blueprint prefix
- register alias for the home page
- fix navbar and admin dashboard links to include blueprint name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6874017711f4832599f1056a26a01643