### PR TITLE
Fix blueprint endpoints and add setup script

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -3,7 +3,8 @@ from services.project_manager import ProjectManager
 from services.comment_manager import CommentManager
 from utils.security import admin_required
 
-admin_bp = Blueprint('admin_bp', __name__)
+# Blueprint with short name used for endpoint prefix
+admin_bp = Blueprint('admin', __name__)
 
 
 def _manager():
@@ -32,7 +33,7 @@ def admin_login():
         user = get_user(email)
         if user and user['is_admin'] and check_password(email, password):
             session['admin'] = email
-            return redirect(url_for('admin_bp.admin'))
+            return redirect(url_for('admin.admin'))
     return render_template('admin_login_form.html')
 
 
@@ -56,14 +57,14 @@ def admin_add_project():
     video_url = request.form['video_url']
     client_email = request.form['client_email']
     mgr.add_project(title, category, video_url, client_email)
-    return redirect(url_for('admin_bp.admin'))
+    return redirect(url_for('admin.admin'))
 
 
 @admin_bp.route('/logout', methods=['POST'])
 @admin_required
 def admin_logout():
     session.pop('admin', None)
-    return redirect(url_for('admin_bp.admin'))
+    return redirect(url_for('admin.admin'))
 
 
 @admin_bp.route('/project/<int:project_id>/update', methods=['POST'])
@@ -73,7 +74,7 @@ def admin_update_project(project_id):
     video_url = request.form.get('video_url', '')
     client_email = request.form.get('client_email', '')
     mgr.update_project_video(project_id, video_url, client_email)
-    return redirect(url_for('admin_bp.admin'))
+    return redirect(url_for('admin.admin'))
 
 
 @admin_bp.route('/project/<int:project_id>/activate', methods=['POST'])
@@ -81,7 +82,7 @@ def admin_update_project(project_id):
 def admin_activate_payment(project_id):
     mgr = _manager()
     mgr.activate_payment(project_id)
-    return redirect(url_for('admin_bp.admin'))
+    return redirect(url_for('admin.admin'))
 
 
 @admin_bp.route('/project/<int:project_id>/delete', methods=['POST'])
@@ -89,5 +90,5 @@ def admin_activate_payment(project_id):
 def admin_delete_video(project_id):
     mgr = _manager()
     mgr.delete_video(project_id)
-    return redirect(url_for('admin_bp.admin'))
+    return redirect(url_for('admin.admin'))
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,3 @@
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -7,6 +7,6 @@
     <a href="{{ url_for('forum_index') }}" class="nav-link">VFORUM</a>
     <a href="{{ url_for('client.academy') }}" class="nav-link">ACADEMIA</a>
     <a href="{{ url_for('client.dashboard') }}" class="nav-link">DASHBOARD</a>
-    <a href="{{ url_for('admin_bp.admin') }}" class="nav-link">ADMIN</a>
+    <a href="{{ url_for('admin.admin') }}" class="nav-link">ADMIN</a>
   </nav>
 </header>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -4,12 +4,12 @@
 <div class="dashboard-container">
   <div class="dashboard-header">
     <h2>Panel Admin</h2>
-    <form action="{{ url_for('admin_bp.admin_logout') }}" method="post" style="display:inline;">
+    <form action="{{ url_for('admin.admin_logout') }}" method="post" style="display:inline;">
       <button type="submit">Salir</button>
     </form>
   </div>
   <div class="dashboard-login" style="margin-bottom:1rem;">
-    <form action="{{ url_for('admin_bp.admin_add_project') }}" method="post">
+    <form action="{{ url_for('admin.admin_add_project') }}" method="post">
       <input type="text" name="title" placeholder="Título" required>
       <input type="text" name="category" placeholder="Categoría" required>
       <input type="text" name="video_url" placeholder="URL" required>
@@ -21,19 +21,19 @@
     {% for p in projects %}
     <div class="project-card">
       <h4>{{ p.title }}</h4>
-      <form action="{{ url_for('admin_bp.admin_update_project', project_id=p.id) }}" method="post">
+      <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
         <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" style="width:100%;margin-bottom:.5rem;">
         <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" style="width:100%;margin-bottom:.5rem;">
         <button type="submit">Guardar</button>
       </form>
-      <form action="{{ url_for('admin_bp.admin_activate_payment', project_id=p.id) }}" method="post" style="margin-top:.5rem;">
+      <form action="{{ url_for('admin.admin_activate_payment', project_id=p.id) }}" method="post" style="margin-top:.5rem;">
         {% if not p.paid %}
         <button type="submit" class="pay-btn">Activar 50%</button>
         {% else %}
         <span>Pago activado</span>
         {% endif %}
       </form>
-      <form action="{{ url_for('admin_bp.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" style="margin-top:.5rem;">
+      <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" style="margin-top:.5rem;">
         <button type="submit">Eliminar Video</button>
       </form>
     </div>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="dashboard-container">
   <div class="dashboard-login">
-    <a href="{{ url_for('admin_bp.admin_signup') }}" class="btn">Crear admin</a>
-    <a href="{{ url_for('admin_bp.admin_login') }}" class="btn">Log in</a>
+    <a href="{{ url_for('admin.admin_signup') }}" class="btn">Crear admin</a>
+    <a href="{{ url_for('admin.admin_login') }}" class="btn">Log in</a>
   </div>
 </div>
 {% endblock %}

--- a/utils/security.py
+++ b/utils/security.py
@@ -15,6 +15,6 @@ def admin_required(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         if not session.get('admin'):
-            return redirect(url_for('admin_bp.admin'))
+            return redirect(url_for('admin.admin'))
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Summary
- register admin blueprint with name `admin`
- update all `url_for` references to use new endpoint prefix
- keep alias '/' as `home`
- add helper shell script for virtual environment setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68740695dcd08325bda07812d8a5568f