### PR TITLE
Fix blueprint registration

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,6 @@ def create_app():
     migrate.init_app(app, db)
     app.register_blueprint(admin_bp, url_prefix='/admin')
     app.register_blueprint(client_bp)
-    app.add_url_rule('/', endpoint='home', view_func=client_bp.view_functions['home'])
     app.teardown_appcontext(close_db)
 
     with app.app_context():


### PR DESCRIPTION
## Summary
- remove `add_url_rule` for root endpoint
- rely on blueprint registration for `client.home`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `flask --app app run` *(fails: command not found: flask)*

------
https://chatgpt.com/codex/tasks/task_e_687410f716fc8325a9ef3aacc5dd57d0