### PR TITLE
Add Alembic migrations with backup workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ __pycache__/
 *.sqlite3
 *.log
 logs/
-migrations/

--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ Las huellas se multiplican, revelando senderos nunca antes explorados.
 Sus ecos perdurarán para guiar a los buscadores de inspiración.
 La sinfonía digital de la bestia nunca cesa, alentando a cada viajero a continuar.
 Su rugido invita a nuevas almas a unirse en esta traves\u00eda interminable.
+Sus pasos trazan mapas que otros seguirán con asombro.

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+This directory contains Alembic migration scripts managed by Flask-Migrate.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,24 @@
+[alembic]
+script_location = migrations
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(message)s

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,27 @@
+from logging.config import fileConfig
+
+from flask import current_app
+from alembic import context
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+def run_migrations_offline():
+    url = current_app.config['SQLALCHEMY_DATABASE_URI']
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = current_app.extensions['migrate'].db.engine
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,14 @@
+"""${message}"""
+revision = '${up_revision}'
+down_revision = ${down_revision | repr}
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    pass
+
+def downgrade():
+    pass

--- a/migrations/versions/0001_initial.py
+++ b/migrations/versions/0001_initial.py
@@ -1,0 +1,47 @@
+"""Initial schema."""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if 'clients' not in inspector.get_table_names():
+        op.create_table(
+            'clients',
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('username', sa.String(80)),
+            sa.Column('email', sa.String(120), unique=True, nullable=False),
+            sa.Column('created_at', sa.DateTime, server_default=sa.text('CURRENT_TIMESTAMP')),
+        )
+    if 'projects' not in inspector.get_table_names():
+        op.create_table(
+            'projects',
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('title', sa.String(120)),
+            sa.Column('category', sa.String(120)),
+            sa.Column('video_url', sa.String(255)),
+            sa.Column('client_id', sa.Integer, sa.ForeignKey('clients.id')),
+            sa.Column('active', sa.Boolean, server_default='0'),
+            sa.Column('paid', sa.Boolean, server_default='0'),
+            sa.Column('progress', sa.Float, server_default='0'),
+            sa.Column('status', sa.String(50), server_default='active'),
+            sa.Column('script', sa.Text),
+            sa.Column('download', sa.String(255)),
+        )
+    if 'users' not in inspector.get_table_names():
+        op.create_table(
+            'users',
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('email', sa.String(120), unique=True, nullable=False),
+            sa.Column('password', sa.String(128)),
+            sa.Column('is_admin', sa.Boolean, server_default='0'),
+            sa.Column('verified', sa.Boolean, server_default='0'),
+            sa.Column('verification_code', sa.String(120)),
+            sa.Column('profile_pic', sa.String(256)),
+            sa.Column('created_at', sa.DateTime, server_default=sa.text('CURRENT_TIMESTAMP')),
+        )

--- a/migrations/versions/0002_projects_created_at.py
+++ b/migrations/versions/0002_projects_created_at.py
@@ -1,0 +1,23 @@
+"""Add created_at to projects."""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = [c['name'] for c in insp.get_columns('projects')]
+    if 'created_at' not in cols:
+        op.add_column('projects', sa.Column('created_at', sa.DateTime, server_default=sa.text('CURRENT_TIMESTAMP')))
+        op.execute("UPDATE projects SET created_at=CURRENT_TIMESTAMP WHERE created_at IS NULL")
+
+def downgrade():
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = [c['name'] for c in insp.get_columns('projects')]
+    if 'created_at' in cols:
+        op.drop_column('projects', 'created_at')

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: python
     plan: free
     buildCommand: ""
-    startCommand: "gunicorn app:app"
+    startCommand: "./scripts/start.sh"
     envVars:
       - key: PYTHON_VERSION
         value: 3.11

--- a/scripts/db_upgrade.sh
+++ b/scripts/db_upgrade.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+DB_FILE="${DB_PATH:-db/forum.db}"
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+BACKUP="${DB_FILE%.db}.backup_${TIMESTAMP}.db"
+cp "$DB_FILE" "$BACKUP"
+if flask db upgrade; then
+  echo "Database upgraded. Backup stored at $BACKUP"
+else
+  echo "Upgrade failed. Restoring backup." >&2
+  cp "$BACKUP" "$DB_FILE"
+  exit 1
+fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+source "$HOME/.venv/bin/activate" 2>/dev/null || true
+./scripts/db_upgrade.sh
+exec gunicorn app:app

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,25 @@
+import os
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+
+
+def test_alembic_upgrade_preserves_data(tmp_path):
+    db_src = Path('db/forum.db')
+    db_copy = tmp_path / 'forum.db'
+    shutil.copy(db_src, db_copy)
+
+    conn = sqlite3.connect(db_copy)
+    tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    before = {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
+    conn.close()
+
+    env = dict(os.environ, DB_PATH=str(db_copy))
+    subprocess.run(['alembic', '-c', 'migrations/alembic.ini', 'upgrade', 'head'], check=True, env=env)
+
+    conn = sqlite3.connect(db_copy)
+    after = {t: conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0] for t in tables}
+    conn.close()
+
+    assert before == after


### PR DESCRIPTION
## Summary
- add migrations directory and sample revisions
- add upgrade script with automatic backup
- start Gunicorn using a startup script that runs migrations
- provide migration preservation test
- update Render config and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687415e8fc308325911f865cec73212d