### PR TITLE
Implement dark admin theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ La sinfonía digital de la bestia nunca cesa, alentando a cada viajero a continu
 Su rugido invita a nuevas almas a unirse en esta traves\u00eda interminable.
 Sus pasos trazan mapas que otros seguirán con asombro.
 Nuevos viajeros aportan sus visiones al crecer de la bestia.
+Las constelaciones se reconfiguran cada vez que un proyecto se completa.

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -21,7 +21,16 @@ def admin():
     cmt = _comments()
     projects = mgr.get_all_projects()
     comments = cmt.get_all_comments()
-    return render_template('admin_dashboard.html', projects=projects, comments=comments)
+    stats = {
+        'total': len(projects),
+        'active': sum(1 for p in projects if p.get('status') == 'active'),
+        'completed': sum(1 for p in projects if p.get('status') == 'completed'),
+        'pending': sum(1 for p in projects if not p.get('paid'))
+    }
+    open_projects = [p for p in projects if p.get('status') != 'completed']
+    return render_template('admin_dashboard.html', projects=projects,
+                           comments=comments, stats=stats,
+                           open_projects=open_projects)
 
 
 @admin_bp.route('/login', methods=['GET', 'POST'])

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1,52 +1,106 @@
 :root {
-  --bg-primary: #2d3748;
-  --bg-secondary: #4a5568;
-  --text-primary: #e2e8f0;
-  --text-secondary: #a0aec0;
+  --bg-primary: #1e2128;
+  --bg-secondary: #272b33;
+  --bg-tertiary: #323642;
+  --text-primary: #e1e3ea;
+  --text-secondary: #a5a7b3;
+  --accent-green: #2ecc71;
+  --accent-red:   #e74c3c;
+  --accent-blue:  #3498db;
+  --border-color: #3a3f51;
 }
 
-/* Utility classes */
-.inline-form { display: inline; }
-.mb-1 { margin-bottom: 1rem; }
-.mt-half { margin-top: .5rem; }
-.full-input { width: 100%; margin-bottom: .5rem; }
-
-/* Layout */
-.dashboard-container {
+body {
   background: var(--bg-primary);
   color: var(--text-primary);
+}
+
+.app-container {
+  display: flex;
   min-height: 100vh;
 }
-.dashboard-header {
+
+.sidebar {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  width: 220px;
+  padding: 1rem;
+}
+.sidebar .avatar img {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  display: block;
+  margin: 0 auto 1rem;
+}
+.menu .menu-item {
+  display: block;
+  padding: .5rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+.menu .menu-item.active {
+  color: var(--text-primary);
+}
+
+.main-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: var(--bg-secondary);
+  background: var(--bg-tertiary);
   padding: 1rem;
-  border-radius: 4px;
+  margin-bottom: 1rem;
 }
-.dashboard-login {
+.search-bar input {
+  width: 200px;
+}
+
+.card {
   background: var(--bg-secondary);
-  color: var(--text-primary);
-  padding: 1rem;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-}
-.project-card {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
   padding: 1rem;
-  border-radius: 4px;
 }
-.comments-admin li {
-  border-bottom: 1px solid var(--text-secondary);
-  padding: .25rem 0;
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
-.btn, button {
-  background: var(--text-secondary);
+.stat-card .stat-value {
+  font-size: 1.8rem;
+}
+
+.btn {
+  background: var(--accent-blue);
   color: var(--text-primary);
   border: none;
   padding: .5rem 1rem;
   border-radius: 4px;
   cursor: pointer;
 }
-.btn:hover, button:hover { background: #718096; }
+.btn-success { background: var(--accent-green); }
+.btn-danger { background: var(--accent-red); }
+.form-control {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  border-radius: 4px;
+  padding: .5rem;
+}
+.inline-form { display: inline; }
+.mb-1 { margin-bottom: 1rem; }
+.mt-half { margin-top: .5rem; }
+.full-input { width: 100%; margin-bottom: .5rem; }
+
+.comments-admin li {
+  border-bottom: 1px solid var(--border-color);
+  padding: .25rem 0;
+}
+

--- a/static/img/avatar.png
+++ b/static/img/avatar.png
@@ -1,0 +1,1 @@
+placeholder

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var ctx = document.getElementById('txnChart');
+  if (ctx) {
+    new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['Paid', 'Pending'],
+        datasets: [{
+          data: [60, 40],
+          backgroundColor: ['#2ecc71', '#e74c3c']
+        }]
+      },
+      options: {
+        plugins: {
+          legend: {
+            labels: {
+              color: getComputedStyle(document.documentElement).getPropertyValue('--text-secondary')
+            }
+          }
+        }
+      }
+    });
+  }
+});

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+{% endblock %}
+
+{% block header %}
+{% include 'admin/header.html' %}
+{% endblock %}
+
+{% block content %}
+<div class="app-container">
+  {% include 'admin/sidebar.html' %}
+  <div class="main-content">
+    {% block admin_content %}{% endblock %}
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='js/admin.js') }}"></script>
+{% endblock %}

--- a/templates/admin/header.html
+++ b/templates/admin/header.html
@@ -1,0 +1,11 @@
+<header class="header">
+  <div class="logo">EEVI</div>
+  <form class="search-bar">
+    <input type="text" class="form-control" placeholder="Buscar" />
+  </form>
+  <div class="header-actions">
+    <i class="fa fa-bell"></i>
+    <i class="fa fa-envelope"></i>
+    <div class="user-dropdown">Admin</div>
+  </div>
+</header>

--- a/templates/admin/sidebar.html
+++ b/templates/admin/sidebar.html
@@ -1,0 +1,10 @@
+<aside class="sidebar">
+  <div class="avatar">
+    <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin" />
+  </div>
+  <nav class="menu">
+    <a href="{{ url_for('admin.admin') }}" class="menu-item{% if request.endpoint == 'admin.admin' %} active{% endif %}">
+      <i class="fa fa-chart-pie"></i> Dashboard
+    </a>
+  </nav>
+</aside>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,53 +1,90 @@
-{% extends 'base.html' %}
+{% extends 'admin/base.html' %}
 {% block title %}Panel Admin{% endblock %}
-{% block content %}
-<div class="dashboard-container">
-  <div class="dashboard-header">
-    <h2>Panel Admin</h2>
-    <form action="{{ url_for('admin.admin_logout') }}" method="post" class="inline-form">
-      <button type="submit">Salir</button>
-    </form>
+{% block admin_content %}
+<header class="header">
+  <h2>Panel Admin</h2>
+  <form action="{{ url_for('admin.admin_logout') }}" method="post" class="inline-form">
+    <button type="submit" class="btn btn-danger">Salir</button>
+  </form>
+</header>
+
+<div class="stats-grid">
+  <div class="card stat-card">
+    <div class="stat-value">{{ stats.total }}</div>
+    <div class="stat-label">Proyectos</div>
   </div>
-  <div class="dashboard-login mb-1">
-    <form action="{{ url_for('admin.admin_add_project') }}" method="post">
-      <input type="text" name="title" placeholder="Título" required class="full-input">
-      <input type="text" name="category" placeholder="Categoría" required class="full-input">
-      <input type="text" name="video_url" placeholder="URL" required class="full-input">
-      <input type="email" name="client_email" placeholder="Cliente" required class="full-input">
-      <button type="submit">Agregar</button>
-    </form>
+  <div class="card stat-card">
+    <div class="stat-value">{{ stats.active }}</div>
+    <div class="stat-label">Activos</div>
   </div>
-  <div class="projects">
-    {% for p in projects %}
-    <div class="project-card">
-      <h4>{{ p.title }}</h4>
-      <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
-        <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" class="full-input">
-        <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" class="full-input">
-        <button type="submit">Guardar</button>
-      </form>
-      <form action="{{ url_for('admin.admin_activate_payment', project_id=p.id) }}" method="post" class="mt-half">
-        {% if not p.paid %}
-        <button type="submit" class="pay-btn">Activar 50%</button>
-        {% else %}
-        <span>Pago activado</span>
-        {% endif %}
-      </form>
-      <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" class="mt-half">
-        <button type="submit">Eliminar Video</button>
-      </form>
-    </div>
-    {% endfor %}
+  <div class="card stat-card">
+    <div class="stat-value">{{ stats.completed }}</div>
+    <div class="stat-label">Completados</div>
   </div>
-  <h3>Comentarios recientes</h3>
-  <ul class="comments-admin">
-    {% for c in comments %}
-    <li><strong>{{ c.user_email }}</strong> en <em>{{ c.project }}</em>: {{ c.text }} <span class="date">{{ c.date }}</span></li>
-    {% endfor %}
-  </ul>
+  <div class="card stat-card">
+    <div class="stat-value">{{ stats.pending }}</div>
+    <div class="stat-label">Pendientes</div>
+  </div>
 </div>
+
+<div class="row">
+  <div class="card">
+    <h3>Transaction History</h3>
+    <canvas id="txnChart"></canvas>
+  </div>
+  <div class="card">
+    <h3>Open Projects</h3>
+    <ul class="open-projects">
+      {% for project in open_projects %}
+      <li>
+        <span class="project-title">{{ project.title }}</span>
+        <span class="project-meta">{{ project.client_email }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+
+<div class="dashboard-login mb-1">
+  <form action="{{ url_for('admin.admin_add_project') }}" method="post">
+    <input type="text" name="title" placeholder="Título" required class="form-control full-input">
+    <input type="text" name="category" placeholder="Categoría" required class="form-control full-input">
+    <input type="text" name="video_url" placeholder="URL" required class="form-control full-input">
+    <input type="email" name="client_email" placeholder="Cliente" required class="form-control full-input">
+    <button type="submit" class="btn btn-primary">Agregar</button>
+  </form>
+</div>
+<div class="projects">
+  {% for p in projects %}
+  <div class="project-card card">
+    <h4>{{ p.title }}</h4>
+    <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
+      <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" class="form-control full-input">
+      <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" class="form-control full-input">
+      <button type="submit" class="btn btn-primary">Guardar</button>
+    </form>
+    <form action="{{ url_for('admin.admin_activate_payment', project_id=p.id) }}" method="post" class="mt-half">
+      {% if not p.paid %}
+      <button type="submit" class="btn btn-success pay-btn">Activar 50%</button>
+      {% else %}
+      <span>Pago activado</span>
+      {% endif %}
+    </form>
+    <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" class="mt-half">
+      <button type="submit" class="btn btn-danger">Eliminar Video</button>
+    </form>
+  </div>
+  {% endfor %}
+</div>
+<h3>Comentarios recientes</h3>
+<ul class="comments-admin">
+  {% for c in comments %}
+  <li><strong>{{ c.user_email }}</strong> en <em>{{ c.project }}</em>: {{ c.text }} <span class="date">{{ c.date }}</span></li>
+  {% endfor %}
+</ul>
 {% endblock %}
 {% block scripts %}
+{{ super() }}
 <script>
 function confirmDelete(){
   if(!confirm('¿Seguro que quieres eliminar el video?')) return false;

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/admin.css') }}">
+  {% block extra_head %}{% endblock %}
 </head>
 <body>
   {% block header %}{% include '_header.html' %}{% endblock %}


### PR DESCRIPTION
## Summary
- extend base template with optional `extra_head` block
- create admin layout using sidebar, header and Chart.js
- style dashboard with new dark theme variables
- compute stats and open projects in admin route
- update README

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6874261949d88325940c1a1a3c6287d5