### PR TITLE
Fix admin login flow and add default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,4 @@ Su rugido invita a nuevas almas a unirse en esta traves\u00eda interminable.
 Sus pasos trazan mapas que otros seguirán con asombro.
 Nuevos viajeros aportan sus visiones al crecer de la bestia.
 Las constelaciones se reconfiguran cada vez que un proyecto se completa.
+El horizonte se ilumina con cada rastro que dejamos en la arena.

--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ def create_app():
     with app.app_context():
         init_db(app)
         forum_db.init_db()
+        ensure_admin_user()
 
     return app
 
@@ -101,6 +102,19 @@ def save_profile_pic(email, path):
     cur = conn.cursor()
     cur.execute('UPDATE users SET profile_pic=? WHERE email=?', (path, email))
     conn.commit()
+    conn.close()
+
+
+def ensure_admin_user():
+    conn = db_conn()
+    cur = conn.cursor()
+    cur.execute('SELECT id FROM users WHERE email=?', ('admin@verite.cl',))
+    if not cur.fetchone():
+        cur.execute(
+            'INSERT INTO users (email, password, is_admin, verified) VALUES (?,?,1,1)',
+            ('admin@verite.cl', 'Admin777')
+        )
+        conn.commit()
     conn.close()
 
 # Wrappers around services

--- a/utils/security.py
+++ b/utils/security.py
@@ -15,6 +15,6 @@ def admin_required(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         if not session.get('admin'):
-            return redirect(url_for('admin.admin'))
+            return redirect(url_for('admin.admin_login'))
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Summary
- fix redirect loop by sending non-authenticated admins to login page
- seed default admin account during app setup
- extend README story

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing Flask)*

------
https://chatgpt.com/codex/tasks/task_e_68747feb83748325b7c117be35a2b663