### PR TITLE
Set fixed admin password and extend README narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ Sus pasos trazan mapas que otros seguirán con asombro.
 Nuevos viajeros aportan sus visiones al crecer de la bestia.
 Las constelaciones se reconfiguran cada vez que un proyecto se completa.
 El horizonte se ilumina con cada rastro que dejamos en la arena.
+Cada destello anuncia un nuevo ciclo de creación compartida.

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,5 +1,4 @@
 import sqlite3
-import secrets
 
 from utils.db import get_db
 
@@ -18,7 +17,8 @@ def ensure_admin_user():
     if admin:
         return admin['id']
 
-    password = secrets.token_hex(8)
+    # Default admin password should be fixed for simplicity
+    password = "admin2025"
     conn.execute(
         "INSERT INTO users (email, password, is_admin, verified) VALUES (?, ?, 1, 1)",
         ("admin@verite.cl", password),


### PR DESCRIPTION
## Summary
- ensure the default admin account uses password `admin2025`
- keep the README evolving by adding another line to the story

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68748c6ead788325bbce90811d030b73