### PR TITLE
Implement motivational quote feature and fix admin stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from routes.client import client_bp
 from services.project_manager import ProjectManager
 from services.comment_manager import CommentManager
 from modules import forum as forum_db
+from utils.quotes import get_random_quote
 from modules.forum import (
     get_topic,
     get_topic_by_id,
@@ -31,6 +32,7 @@ def create_app():
     app.config.from_object(config[os.getenv('APP_ENV', 'development')])
     db.init_app(app)
     migrate.init_app(app, db)
+    app.jinja_env.globals['get_random_quote'] = get_random_quote
     app.register_blueprint(admin_bp, url_prefix='/admin')
     app.register_blueprint(client_bp)
     app.teardown_appcontext(close_db)

--- a/routes/client.py
+++ b/routes/client.py
@@ -173,5 +173,6 @@ def ver_pack(pack_id):
 
 @client_bp.route('/api/random-quote')
 def api_random_quote():
+    """Devuelve una frase motivacional en formato JSON."""
     from utils.quotes import get_random_quote
-    return jsonify({"quote": get_random_quote()})
+    return jsonify({"quote": get_random_quote()}), 200

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -1,11 +1,5 @@
 {% extends 'base.html' %}
 
-{% macro stat(label, value) %}
-<div class="stat-card">
-  <div class="stat-value">{{ value }}</div>
-  <div class="stat-label">{{ label }}</div>
-</div>
-{% endmacro %}
 
 {% block head_admin %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/admin_modern.css') }}">
@@ -30,13 +24,20 @@
       </form>
     </header>
 
-    {% set s = stats %}
-    <div class="stats-grid">
-      {{ stat('Total', s.total) }}
-      {{ stat('Activos', s.active) }}
-      {{ stat('Termin.', s.completed) }}
-      {{ stat('Pend.', s.pending) }}
-    </div>
+  {% set stat_items = [
+     ('Proyectos',         stats.total),
+     ('Activos',           stats.active),
+     ('Completados',       stats.completed),
+     ('Pendientes',        stats.pending)
+  ] %}
+  <div class="stats-grid">
+    {% for label, value in stat_items %}
+      <div class="stat-card">
+          <div class="stat-value">{{ value }}</div>
+          <div class="stat-label">{{ label }}</div>
+      </div>
+    {% endfor %}
+  </div>
 
     <form class="project-form" action="{{ url_for('admin.admin_add_project') }}" method="post">
       <input type="text" name="title" placeholder="Título" required>

--- a/utils/quotes.py
+++ b/utils/quotes.py
@@ -1,17 +1,13 @@
-import random
+from random import choice
 
-try:
-    from modules.forum import INSPIRATIONAL_QUOTES
-except Exception:
-    INSPIRATIONAL_QUOTES = [
-        "Sigue creando, pase lo que pase"
-    ]
+_QUOTES = [
+    "La creatividad es inteligencia divirtiéndose.",
+    "El éxito es la suma de pequeños esfuerzos repetidos cada día.",
+    "Transforma tus ideas en realidad.",
+    "Cada proyecto es una oportunidad para crecer.",
+    "La constancia vence al talento cuando el talento no se esfuerza."
+]
 
 def get_random_quote() -> str:
-    """Devuelve una frase aleatoria.
-
-    Si las frases no están disponibles, retorna un fallback.
-    """
-    if not INSPIRATIONAL_QUOTES:
-        return ""
-    return random.choice(INSPIRATIONAL_QUOTES)
+    """Devuelve una frase motivacional aleatoria."""
+    return choice(_QUOTES)


### PR DESCRIPTION
## Summary
- add a simple quotes helper returning random quotes
- expose `get_random_quote` in Jinja environment
- provide JSON endpoint `/api/random-quote`
- fix statistics loop in admin panel template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*
- `gunicorn app:app -b 127.0.0.1:8000 -t 2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a198270883259857472190b98fc3