### PR TITLE
Modern header redesign

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -1,0 +1,32 @@
+/* --- Header Moderno EEVI --- */
+header.app-bar{
+  position:fixed;top:0;left:0;width:100%;
+  height:56px;padding:0 32px;
+  display:flex;align-items:center;justify-content:space-between;
+  background:rgba(0,0,0,.55);backdrop-filter:blur(6px);
+  z-index:1000;
+}
+.logo{
+  font-family:'Inter',sans-serif;font-weight:800;letter-spacing:.04em;
+  font-size:clamp(2rem,4vw,5rem);line-height:1;color:#fff;text-decoration:none;
+}
+#navToggle{
+  background:none;border:none;
+  display:flex;flex-direction:column;gap:6px;padding:4px;cursor:pointer;
+}
+#navToggle span{
+  width:32px;height:4px;background:#fff;border-radius:2px;
+  transition:all .3s;
+}
+#navPanel{
+  position:fixed;top:-100vh;left:0;width:100%;
+  background:rgba(0,0,0,.85);backdrop-filter:blur(8px);
+  display:flex;flex-direction:column;align-items:center;
+  gap:24px;padding:96px 0 48px;
+  transition:top .45s ease, opacity .45s ease;opacity:0;
+}
+#navPanel.open{top:0;opacity:1}
+#navPanel a{
+  color:#fff;text-decoration:none;font-size:clamp(1.2rem,2vw,2rem);
+  font-weight:600;letter-spacing:.03em;
+}

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('navToggle');
+  const panel = document.getElementById('navPanel');
+  btn?.addEventListener('click', () => panel.classList.toggle('open'));
+});

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,29 +1,17 @@
-<header id="site-header">
-    <a class="logo" href="{{ url_for('client.home') }}">VERITÉ</a>
+<header class="app-bar">
+  <a class="logo" href="{{ url_for('client.home') }}">VERITÉ</a>
 
-    <!-- Botón hamburguesa -->
-    <button id="hamburgerBtn" aria-label="Abrir menú" aria-expanded="false">
-        <span class="line"></span><span class="line"></span><span class="line"></span>
-    </button>
+  <button id="navToggle" aria-label="Abrir menú">
+    <span></span><span></span><span></span>
+  </button>
 
-    <!-- Menú deslizable -->
-    <nav id="mobileMenu">
-        {% for name, endpoint in [
-            ('Inicio',     'client.home'),
-            ('Packs',      'client.packs'),
-            ('Services',   'client.services_page'),
-            ('VFORUM',     'forum_index'),
-            ('Academia',   'client.academy'),
-            ('Dashboard',  'client.dashboard'),
-            ('Admin',      'admin.admin') ] %}
-            <a class="nav-link" href="{{ url_for(endpoint) }}">{{ name }}</a>
-        {% endfor %}
-
-        <div id="quoteRotator">{{ get_random_quote() }}</div>
-    </nav>
+  <nav id="navPanel">
+    <a href="{{ url_for('client.home') }}">Inicio</a>
+    <a href="{{ url_for('client.packs') }}">Packs</a>
+    <a href="{{ url_for('client.services_page') }}">Services</a>
+    <a href="{{ url_for('forum_index') }}">VForum</a>
+    <a href="{{ url_for('client.academy') }}">Academia</a>
+    <a href="{{ url_for('client.dashboard') }}">Dashboard</a>
+    <a href="{{ url_for('admin.admin') }}">Admin</a>
+  </nav>
 </header>
-
-{% block extra_head %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/navbar_hamburger.css') }}">
-  <script defer src="{{ url_for('static', filename='js/navbar_hamburger.js') }}"></script>
-{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
   <!-- Fuente principal para la sección de administración -->
   <link href="https://fonts.googleapis.com/css2?family=Verite+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/site.css') }}">
   {% block head_admin %}{% endblock %}
   {% block extra_head %}{% endblock %}
 </head>
@@ -19,5 +20,6 @@
   </main>
   <script src="/static/js/main.js"></script>
 {% block scripts %}{% endblock %}
+  <script src="{{ url_for('static', filename='js/nav.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor `_header.html` with modern mobile nav
- style header in new `site.css`
- add small nav.js to handle menu toggle
- load new assets from `base.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6874a5cccd008325b8ae99fb01f9e1ef