### PR TITLE
Add rotating words on homepage

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -42,3 +42,12 @@ header.app-bar{
   border:none;border-radius:0;
 }
 #navPanel a:hover{background:none;}
+
+/* -------- Rotador de palabras (home) -------- */
+.rotator{display:inline-block;white-space:nowrap;}
+.fade{opacity:0;filter:blur(6px);transition:opacity 1s ease,filter 1s ease;}
+.fade.show{opacity:1;filter:blur(0);}
+/* tiempos de permanencia se controlan por JS */
+
+.primary{color:var(--accent);}
+.secondary{color:var(--primary);}

--- a/static/js/title-rotator.js
+++ b/static/js/title-rotator.js
@@ -1,0 +1,41 @@
+'use strict';
+document.addEventListener('DOMContentLoaded', () => {
+  const words1 = ['SONIDO', 'IMAGEN', 'SOLUCIÓN'];
+  const words2 = ['AUTÉNTICOS', 'ORIGINALES', 'INSPIRADORES', 'VIBRANTES', 'PROFESIONALES', 'MAGNIFICOS'];
+  const el1 = document.getElementById('wordPrimary');
+  const el2 = document.getElementById('wordSecondary');
+
+  let i1 = 0;
+  let i2 = 0;
+
+  const fadeIn = 4000;
+  const fadeOut = 1000;
+  const visible1 = 10000;
+  const visibleOptions = [12000, 13000, 15000];
+
+  function cyclePrimary() {
+    el1.classList.remove('show');
+    setTimeout(() => {
+      i1 = (i1 + 1) % words1.length;
+      el1.textContent = words1[i1];
+      el1.classList.add('show');
+    }, fadeOut);
+    setTimeout(cyclePrimary, fadeOut + fadeIn + visible1);
+  }
+
+  function cycleSecondary() {
+    const visible2 = visibleOptions[Math.floor(Math.random() * visibleOptions.length)];
+    el2.classList.remove('show');
+    setTimeout(() => {
+      i2 = (i2 + 1) % words2.length;
+      el2.textContent = words2[i2];
+      el2.classList.add('show');
+    }, fadeOut);
+    setTimeout(cycleSecondary, fadeOut + fadeIn + visible2);
+  }
+
+  el1.classList.add('show');
+  el2.classList.add('show');
+  setTimeout(cyclePrimary, fadeOut + fadeIn + visible1);
+  setTimeout(cycleSecondary, fadeOut + fadeIn + visibleOptions[Math.floor(Math.random() * visibleOptions.length)]);
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,9 @@
   </main>
   <script src="/static/js/main.js"></script>
 {% block scripts %}{% endblock %}
+  {% if request.endpoint == 'client.home' %}
+  <script src="{{ url_for('static', filename='js/title-rotator.js') }}"></script>
+  {% endif %}
   <script src="{{ url_for('static', filename='js/nav.js') }}"></script>
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,11 +11,10 @@
 <section class="hero" id="inicio">
    <div class="hero-content">
        <div class="hero-badge">🎵 Contenido Real Certificado</div>
-       <h1 class="hero-title">
-           SONIDO <span class="highlight">REAL</span><br>
-           PARA PROYECTOS<br>
-           <span class="highlight">AUTÉNTICOS</span>
-       </h1>
+      <h1 class="hero-title">
+          <span id="wordPrimary" class="rotator fade primary">SONIDO</span> REAL<br>
+          PARA PROYECTOS <span id="wordSecondary" class="rotator fade secondary">AUTÉNTICOS</span>
+      </h1>
        <p class="hero-subtitle">La única plataforma que garantiza grabaciones 100% reales</p>
        <p class="hero-description">
            Cada sonido que ofrecemos ha sido capturado en el mundo real, sin IA, sin bibliotecas genéricas. 


### PR DESCRIPTION
## Summary
- rotate words on home hero title with new JS
- style new rotation and colors
- load script only on home page

## Testing
- `black .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6874bc97e0e483259f7b3aba649d84ba