### PR TITLE
Fix forum index endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,6 +170,12 @@ def forum_index():
         quotes=forum_db.INSPIRATIONAL_QUOTES,
     )
 
+# ─── Alias de endpoint para compatibilidad retroactiva ──
+@app.route('/forum', endpoint='forum.index', methods=['GET'])
+def forum_index_alias():
+    """Alias para que `url_for('forum.index')` funcione sin cambiar templates."""
+    return forum_index()
+
 
 @app.route('/forum/new', methods=['GET', 'POST'])
 def forum_new():


### PR DESCRIPTION
## Summary
- add a `forum.index` alias for the forum landing route

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6874c8c029d4832595628252bf079589