### PR TITLE
Fix join word rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,4 @@ Las constelaciones se reconfiguran cada vez que un proyecto se completa.
 El horizonte se ilumina con cada rastro que dejamos en la arena.
 Cada destello anuncia un nuevo ciclo de creación compartida.
 La tormenta de creatividad nunca se detiene, alimentando el ritmo incansable de la bestia.
+El rumor de sus pasos resuena en la distancia, atrayendo a más soñadores.

--- a/static/css/home_brutalista.css
+++ b/static/css/home_brutalista.css
@@ -232,4 +232,3 @@ body {
     90%  { opacity:1; }
     100% { opacity:0; filter:blur(2px);}
 }
-.word-anim { animation: fadeIO 10s linear forwards; }

--- a/static/js/rotate_words.js
+++ b/static/js/rotate_words.js
@@ -7,18 +7,31 @@ const words = [
   "Youtubers"
 ];
 
-const span   = document.getElementById("dynamic-word");
-let index    = 0;
+document.addEventListener('DOMContentLoaded', () => {
+  const span = document.getElementById('dynamic-word');
+  let index = 0;
 
-function rotate() {
-  // remove previous animation class to restart it
-  span.classList.remove("word-anim");
-  // queue the DOM update so the animation restarts
-  requestAnimationFrame(() => {
-    span.textContent = words[index];
-    span.classList.add("word-anim");
-    index = (index + 1) % words.length;
-  });
-}
-rotate();                               // first run
-setInterval(rotate, 10000);             // 10 s = 1 s fade-in + 8 s visible + 1 s fade-out
+  const fadeIn = 1000;
+  const fadeOut = 500;
+  const minVisible = 4000;
+  const maxVisible = 7000;
+
+  function randomVisible() {
+    return Math.floor(Math.random() * (maxVisible - minVisible + 1)) + minVisible;
+  }
+
+  function cycle() {
+    const visible = randomVisible();
+    span.classList.remove('show');
+    setTimeout(() => {
+      index = (index + 1) % words.length;
+      span.textContent = words[index];
+      span.classList.add('show');
+    }, fadeOut);
+    setTimeout(cycle, fadeOut + fadeIn + visible);
+  }
+
+  span.classList.add('rotator', 'fade', 'show');
+  const start = randomVisible();
+  setTimeout(cycle, fadeOut + fadeIn + start);
+});


### PR DESCRIPTION
## Summary
- unify dynamic word rotation effect between the hero and join sections
- cleanup unused animation class
- extend README story

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68759e47a7c88325be6c23aff0da1e93