### PR TITLE
Drive mp3 previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,22 @@ El horizonte se ilumina con cada rastro que dejamos en la arena.
 Cada destello anuncia un nuevo ciclo de creación compartida.
 La tormenta de creatividad nunca se detiene, alimentando el ritmo incansable de la bestia.
 El rumor de sus pasos resuena en la distancia, atrayendo a más soñadores.
+Cada nuevo sonido es un eco que fortalece su leyenda.
+
+## Probar previews localmente
+
+1. Exporta las variables de entorno:
+   ```bash
+   export GOOGLE_CREDS_JSON='{"..."}'
+   export DRIVE_PREVIEWS_FOLDER="<ID-de-carpeta>"
+   ```
+2. Inicia la aplicación:
+   ```bash
+   flask run
+   ```
+3. Abre el endpoint de pruebas:
+   ```bash
+   curl http://localhost:5000/packs
+   ```
+
+**Nunca** subas a Git el valor de `GOOGLE_CREDS_JSON`.

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from utils.db import db, migrate, get_db, close_db, init_db
 from utils.auth import ensure_admin_user
 from routes.admin import admin_bp
 from routes.client import client_bp
+from routes.packs import packs_bp
 from services.project_manager import ProjectManager
 from services.comment_manager import CommentManager
 from modules import forum as forum_db
@@ -35,6 +36,7 @@ def create_app():
     app.jinja_env.globals['get_random_quote'] = get_random_quote
     app.register_blueprint(admin_bp, url_prefix='/admin')
     app.register_blueprint(client_bp)
+    app.register_blueprint(packs_bp)
     app.teardown_appcontext(close_db)
 
     with app.app_context():

--- a/routes/client.py
+++ b/routes/client.py
@@ -54,9 +54,6 @@ def home():
     return render_template('home.html', latest=latest, packs=packs, services=services, stats=stats)
 
 
-@client_bp.route('/packs')
-def packs():
-    return render_template('packs.html', packs=get_all_packs())
 
 
 @client_bp.route('/services')

--- a/routes/packs.py
+++ b/routes/packs.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, render_template
+from utils.drive_previews import fetch_previews
+
+packs_bp = Blueprint('packs', __name__)
+
+@packs_bp.route('/packs')
+def packs():
+    previews = fetch_previews()
+    return render_template('packs.html', previews=previews)
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,7 @@
   {% if request.endpoint == 'client.home' %}
   <script src="{{ url_for('static', filename='js/title-rotator.js') }}"></script>
   {% endif %}
+  <script src="https://unpkg.com/wavesurfer.js"></script>
   <script src="{{ url_for('static', filename='js/nav.js') }}"></script>
 </body>
 </html>

--- a/templates/packs.html
+++ b/templates/packs.html
@@ -1,20 +1,31 @@
 {% extends 'base.html' %}
 
-{% block title %}Packs Verité{% endblock %}
+{% block title %}Previews{% endblock %}
 
 {% block content %}
-  <h1 class="section-title">PACKS</h1>
-  <p class="section-description">Nuestros packs nacen de sesiones reales y buscan aportar texturas auténticas.</p>
-  <p class="section-description">Seleccionamos lo que de verdad sirve para contar historias con sonido propio.</p>
-  <div class="packs">
-    {% for pack in packs %}
-    <div class="pack-card">
-      <img src="{{ pack.imagen }}" alt="{{ pack.titulo }}">
-      <h2>{{ pack.titulo }}</h2>
-      <p>{{ pack.descripcion }}</p>
-      <p><strong>Precio:</strong> {{ pack.precio }}</p>
-      <a href="/pack/{{ pack.id }}">Ver detalles</a>
-    </div>
-    {% endfor %}
+  <h1>Previews</h1>
+  {% for p in previews %}
+  <div class="preview">
+    <p>{{ p.name }}</p>
+    <div id="wave-{{ loop.index }}" class="h-24 w-full"></div>
+    <button onclick="players[{{ loop.index0 }}].playPause()">Play/Pause</button>
   </div>
+  {% endfor %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    window.players = [];
+    {% for p in previews %}
+    window.players[{{ loop.index0 }}] = WaveSurfer.create({
+      container: '#wave-{{ loop.index }}',
+      waveColor: '#999',
+      progressColor: '#333',
+      height: 80
+    });
+    window.players[{{ loop.index0 }}].load('{{ p.url }}');
+    {% endfor %}
+  </script>
+{% endblock %}
+

--- a/utils/drive_previews.py
+++ b/utils/drive_previews.py
@@ -1,0 +1,27 @@
+import os
+import json
+import functools
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+
+@functools.lru_cache(maxsize=1)
+def fetch_previews():
+    creds_info = json.loads(os.environ["GOOGLE_CREDS_JSON"])
+    creds = service_account.Credentials.from_service_account_info(
+        creds_info, scopes=SCOPES
+    )
+    drive = build("drive", "v3", credentials=creds, cache_discovery=False)
+    res = drive.files().list(
+        q=f"'{os.getenv('DRIVE_PREVIEWS_FOLDER')}' in parents and mimeType contains 'audio/' and trashed=false",
+        fields="files(id,name,size)"
+    ).execute()
+    return [
+        {
+            "name": f["name"].replace('_preview.mp3', ''),
+            "url": f"https://drive.google.com/uc?export=download&id={f['id']}"
+        }
+        for f in res.get('files', [])
+    ]
+


### PR DESCRIPTION
## Summary
- pull mp3 preview list from Google Drive with caching
- show previews using WaveSurfer.js in `/packs`
- add WaveSurfer script in base template
- register new blueprint and remove old route
- document env vars and local test commands
- continue the README story

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68759fc2386c832592b7df57f76385d6