### PR TITLE
feat(fallback): graceful preview & status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.sqlite3
 *.log
 logs/
+static/previews/default_preview.mp3

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Cada destello anuncia un nuevo ciclo de creación compartida.
 La tormenta de creatividad nunca se detiene, alimentando el ritmo incansable de la bestia.
 El rumor de sus pasos resuena en la distancia, atrayendo a más soñadores.
 Cada nuevo sonido es un eco que fortalece su leyenda.
+El futuro se despliega con cada nota que reverbera en la inmensidad.
 
 ## Previews
 
@@ -156,3 +157,10 @@ NUEVO ENDPOINT: `/packs`
    ```
 
 **Nunca** subas a Git el valor de `GOOGLE_CREDS_JSON`.
+
+## Fallback de previews
+
+1. Ubica un mp3 ligero (~100 KB) en `static/previews/default_preview.mp3`.
+2. La variable `GOOGLE_CREDS_JSON` debe ser JSON de una sola línea.
+3. Si prefieres Base64, crea `GOOGLE_CREDS_B64` y el código ya lo soporta.
+4. Usa `/status` para verificar que la app responde.

--- a/routes/client.py
+++ b/routes/client.py
@@ -8,6 +8,12 @@ from utils.validators import is_valid_url
 client_bp = Blueprint('client', __name__)
 
 
+@client_bp.route('/status', methods=['GET'])
+def status():
+    """Health check endpoint."""
+    return jsonify(ok=True)
+
+
 def _projects():
     return ProjectManager(current_app.config['DB_PATH'])
 
@@ -50,16 +56,18 @@ def packs():
 @client_bp.route('/', methods=['GET'])
 def home():
     from modules import forum as forum_db
+    from utils.drive_previews import fetch_previews
     latest = forum_db.get_latest_topic()
     packs = get_all_packs()
     services = get_all_services()
+    previews = fetch_previews()
     stats = {
         'total_sounds': len(packs) * 50 if packs else 800,
         'projects_completed': 120,
         'satisfaction': 98,
         'avg_delivery': '24h'
     }
-    return render_template('home.html', latest=latest, packs=packs, services=services, stats=stats)
+    return render_template('home.html', latest=latest, packs=packs, services=services, stats=stats, previews=previews)
 
 
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -31,6 +31,21 @@
    <div class="bg-pattern"></div>
 </section>
 
+<!-- Previews Section -->
+<section class="section reveal">
+   <div class="section-container">
+       <div class="section-header">
+           <div class="section-badge">🎧 Previews</div>
+           <h2 class="section-title">Escucha un adelanto</h2>
+       </div>
+       {% for p in previews %}
+       <h3>{{ p.name }}</h3>
+       <div id="wave-{{ loop.index }}"></div>
+       <button onclick="players['{{ loop.index }}'].playPause()">Play/Pause</button>
+       {% endfor %}
+   </div>
+</section>
+
 <!-- Stats Section -->
 <section class="section reveal">
    <div class="section-container">
@@ -178,6 +193,19 @@
 {% endblock %}
 
 {% block scripts %}
+{{ super() }}
 <script src="{{ url_for('static', filename='js/home_brutalista.js') }}"></script>
 <script src="{{ url_for('static', filename='js/rotate_words.js') }}" defer></script>
+<script>
+  window.players = {};
+  {% for p in previews %}
+  players['{{ loop.index }}'] = WaveSurfer.create({
+    container: '#wave-{{ loop.index }}',
+    waveColor: '#999',
+    progressColor: '#333',
+    height: 80
+  });
+  players['{{ loop.index }}'].load('{{ p.url }}');
+  {% endfor %}
+</script>
 {% endblock %}

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,13 @@
+import app
+import pytest
+
+@pytest.fixture
+def client():
+    app.app.config['TESTING'] = True
+    with app.app.test_client() as client:
+        yield client
+
+def test_status(client):
+    resp = client.get('/status')
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}

--- a/utils/drive_previews.py
+++ b/utils/drive_previews.py
@@ -1,32 +1,53 @@
 import os
 import json
 import functools
+import base64
+from flask import url_for
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+import google.auth.exceptions
 
 SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
 
+
+def _default():
+    """Return default preview list"""
+    return [
+        {
+            "name": "preview_default",
+            "url": url_for(
+                "static", filename="previews/default_preview.mp3", _external=False
+            ),
+        }
+    ]
+
 @functools.lru_cache(maxsize=1)
 def fetch_previews():
-    creds_info = json.loads(os.environ["GOOGLE_CREDS_JSON"])
-    creds = service_account.Credentials.from_service_account_info(
-        creds_info, scopes=SCOPES
-    )
-    drive = build("drive", "v3", credentials=creds, cache_discovery=False)
     try:
+        creds_json = os.environ.get("GOOGLE_CREDS_JSON", "")
+        if not creds_json and os.getenv("GOOGLE_CREDS_B64"):
+            creds_json = base64.b64decode(os.environ["GOOGLE_CREDS_B64"]).decode()
+        creds_info = json.loads(creds_json)
+        creds = service_account.Credentials.from_service_account_info(
+            creds_info, scopes=SCOPES
+        )
+        drive = build("drive", "v3", credentials=creds, cache_discovery=False)
         res = drive.files().list(
             q=f"'{os.getenv('DRIVE_PREVIEWS_FOLDER')}' in parents and mimeType contains 'audio/' and trashed=false",
             fields="files(id,name,size)"
         ).execute()
-    except HttpError as e:
-        print(f"[Drive API] {e}")
-        return []
-    return [
-        {
-            "name": f["name"].replace('_preview.mp3', ''),
-            "url": f"https://drive.google.com/uc?export=download&id={f['id']}"
-        }
-        for f in res.get('files', [])
-    ]
+        items = [
+            {
+                "name": f["name"].replace('_preview.mp3', ''),
+                "url": f"https://drive.google.com/uc?export=download&id={f['id']}"
+            }
+            for f in res.get('files', [])
+        ]
+        if not items:
+            return _default()
+        return items
+    except (HttpError, google.auth.exceptions.GoogleAuthError, KeyError, ValueError) as e:
+        print(f"[Drive] fallback → {e}")
+        return _default()
 


### PR DESCRIPTION
## Summary
- handle Drive auth issues gracefully
- add default preview fallback
- expose `/status` health check
- show preview waveforms on home
- document fallback setup
- ignore `static/previews/default_preview.mp3`
- add test for `/status`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6875b94f24348325b0756354207b3c4a