### PR TITLE
Mejora UI de Packs con previews de audio y nuevo estilo de tarjetas

### DIFF
--- a/routes/client.py
+++ b/routes/client.py
@@ -47,10 +47,9 @@ def get_all_services():
 
 @client_bp.route('/packs', endpoint='packs')
 def packs():
-    """Muestra la galería de previews de packs."""
-    from utils.drive_previews import fetch_previews
-    previews = fetch_previews()
-    return render_template('packs.html', previews=previews)
+    """Muestra la galería de packs disponibles."""
+    packs = get_all_packs()
+    return render_template('packs.html', packs=packs)
 
 
 @client_bp.route('/', methods=['GET'])
@@ -181,12 +180,14 @@ def project_comments(project_id):
     return jsonify(cm.get_comments(project_id))
 
 
-@client_bp.route('/pack/<string:pack_id>')
-def ver_pack(pack_id):
+@client_bp.route('/packs/<string:slug>', endpoint='pack_detail')
+def pack_detail(slug):
+    """Vista detalle de un pack."""
     packs = get_all_packs()
-    pack = next((p for p in packs if p['id'] == pack_id), None)
+    pack = next((p for p in packs if p['id'] == slug), None)
     if pack:
-        return render_template('pack.html', pack=pack)
+        sounds = pack.get('sounds', [])
+        return render_template('pack_detail.html', pack=pack, sounds=sounds)
     return "Pack no encontrado", 404
 
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -40,3 +40,55 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+
+function drawWaveform(url, canvas, ctx) {
+  fetch(url)
+    .then(r => r.arrayBuffer())
+    .then(buf => ctx.decodeAudioData(buf))
+    .then(data => {
+      const raw = data.getChannelData(0);
+      const step = Math.ceil(raw.length / canvas.width);
+      const amp = canvas.height / 2;
+      const c = canvas.getContext('2d');
+      c.clearRect(0, 0, canvas.width, canvas.height);
+      c.fillStyle = '#00d4b8';
+      for (let i = 0; i < canvas.width; i++) {
+        let min = 1.0;
+        let max = -1.0;
+        for (let j = 0; j < step; j++) {
+          const datum = raw[i * step + j];
+          if (datum < min) min = datum;
+          if (datum > max) max = datum;
+        }
+        c.fillRect(i, (1 + min) * amp, 1, Math.max(1, (max - min) * amp));
+      }
+    })
+    .catch(() => {});
+}
+
+function initWavePlayers() {
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  const audioCtx = new AudioCtx();
+  document.querySelectorAll('[data-audio]').forEach(container => {
+    const url = container.dataset.audio;
+    const audio = new Audio(url);
+    const control = container.querySelector('.audio-control');
+    const playIcon = control.querySelector('.play');
+    const pauseIcon = control.querySelector('.pause');
+    const canvas = container.querySelector('canvas');
+    drawWaveform(url, canvas, audioCtx);
+    control.addEventListener('click', () => {
+      if (audio.paused) {
+        audio.play();
+        playIcon.style.display = 'none';
+        pauseIcon.style.display = 'block';
+      } else {
+        audio.pause();
+        playIcon.style.display = 'block';
+        pauseIcon.style.display = 'none';
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initWavePlayers);

--- a/static/style.css
+++ b/static/style.css
@@ -139,13 +139,14 @@ h1, h2, h3, h4, h5, h6 {
 
 .pack-card {
   background: #111;
-  border-radius: 10px;
-  padding: 1rem;
+  border-radius: 2rem;
+  padding: 1.5rem;
   width: 280px;
   text-align: center;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  transition: transform .3s ease, opacity 0.4s ease-out;
   opacity: 0;
   transform: translateY(20px);
-  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
 }
 
 .pack-card img {
@@ -879,3 +880,28 @@ body.forum-new {
 .comments-admin{list-style:none;padding:0;margin:1rem 0;}
 .comments-admin li{padding:0.25rem 0;border-bottom:1px solid #444;}
 
+
+/* Packs UI enhancement */
+.audio-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.audio-wrapper audio {
+  display: none;
+}
+.audio-control {
+  cursor: pointer;
+}
+.audio-control svg {
+  width: 24px;
+  height: 24px;
+  fill: #fff;
+}
+.waveform {
+  width: 100%;
+  height: 40px;
+  border-radius: 1rem;
+  background: #222;
+}

--- a/templates/pack_detail.html
+++ b/templates/pack_detail.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ pack.titulo or pack.title }}{% endblock %}
+
+{% block content %}
+<div class="pack-detail">
+  <div class="pack-info">
+    <h1>{{ pack.titulo or pack.title }}</h1>
+    <p class="price">{{ pack.precio }}</p>
+    <p class="description">{{ pack.descripcion or pack.description }}</p>
+    <button class="purchase">Comprar Ahora</button>
+  </div>
+  <div class="pack-preview" data-audio="{{ pack.default_preview_url }}">
+    <div class="audio-control">
+      <svg class="play" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+      <svg class="pause" viewBox="0 0 24 24" style="display:none"><path d="M6 19h4V5H6zm8-14v14h4V5z"/></svg>
+    </div>
+    <canvas class="waveform"></canvas>
+  </div>
+</div>
+{% if sounds %}
+<table class="sound-list">
+  <tbody>
+    {% for s in sounds %}
+    <tr data-audio="{{ s.preview_url }}">
+      <td>{{ s.name }}</td>
+      <td>{{ s.duration }}</td>
+      <td><canvas class="waveform"></canvas></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/templates/packs.html
+++ b/templates/packs.html
@@ -3,30 +3,22 @@
 {% block title %}Packs{% endblock %}
 
 {% block content %}
-  <h1>Packs</h1>
-  {% if not previews %}
-  <div>Aún no hay previews disponibles. Sube tus archivos *_preview.mp3 al folder EEVI-Previews en Google Drive.</div>
-  {% else %}
-    {% for p in previews %}
-    <h2>{{ p.name }}</h2>
-    <div id="wave-{{ loop.index }}"></div>
-    <button onclick="players['{{ loop.index }}'].playPause()">Play/Pause</button>
-    {% endfor %}
-  {% endif %}
-{% endblock %}
-
-{% block scripts %}
-  {{ super() }}
-  <script>
-    window.players = {};
-    {% for p in previews %}
-    players['{{ loop.index }}'] = WaveSurfer.create({
-      container: '#wave-{{ loop.index }}',
-      waveColor: '#999',
-      progressColor: '#333',
-      height: 80
-    });
-    players['{{ loop.index }}'].load('{{ p.url }}');
-    {% endfor %}
-  </script>
+<h1 class="section-title">PACKS</h1>
+<div class="packs">
+  {% for pack in packs %}
+  <div class="pack-card" data-audio="{{ pack.default_preview_url }}">
+    <img src="{{ pack.image_url or pack.imagen }}" alt="{{ pack.titulo or pack.title }}">
+    <h2>{{ pack.titulo or pack.title }}</h2>
+    <p>{{ pack.descripcion or pack.description }}</p>
+    <div class="audio-wrapper">
+      <div class="audio-control">
+        <svg class="play" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+        <svg class="pause" viewBox="0 0 24 24" style="display:none"><path d="M6 19h4V5H6zm8-14v14h4V5z"/></svg>
+      </div>
+      <canvas class="waveform"></canvas>
+    </div>
+    <a class="purchase-btn" href="{{ url_for('client.pack_detail', slug=pack.id) }}">Comprar Ahora - {{ pack.precio }}</a>
+  </div>
+  {% endfor %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Resumen
- nuevas tarjetas de packs con imagen, audio y botón naranja
- página de detalle `/packs/<slug>` para cada pack
- estilos para packs y controles de audio
- canvas de waveform y control play/pause con Web Audio API

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6875c8a668d08325aa84dda91b170e04