### PR TITLE
Añade creación, edición y borrado de Packs en Admin

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,6 +154,40 @@ def get_comments(project_id):
 def get_all_comments():
     return _cmt_mgr().get_all_comments()
 
+
+# ----- Admin Packs CRUD -----
+from modules.admin import (
+    admin_packs_list,
+    admin_packs_new,
+    admin_packs_edit,
+    admin_packs_delete,
+)
+from utils.security import admin_required
+
+
+@admin_bp.route('/packs')
+@admin_required
+def admin_packs():
+    return admin_packs_list()
+
+
+@admin_bp.route('/packs/new', methods=['GET', 'POST'])
+@admin_required
+def admin_packs_new_route():
+    return admin_packs_new()
+
+
+@admin_bp.route('/packs/<string:slug>/edit', methods=['GET', 'POST'])
+@admin_required
+def admin_packs_edit_route(slug):
+    return admin_packs_edit(slug)
+
+
+@admin_bp.route('/packs/<string:slug>/delete', methods=['POST'])
+@admin_required
+def admin_packs_delete_route(slug):
+    return admin_packs_delete(slug)
+
 # ------------- Forum routes (remain here) -------------
 
 @app.route('/forum')

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -72,3 +72,11 @@ CREATE TABLE IF NOT EXISTS comments (
     FOREIGN KEY(project_id) REFERENCES projects(id),
     FOREIGN KEY(user_id) REFERENCES users(id)
 );
+
+CREATE TABLE IF NOT EXISTS packs (
+    slug TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    price TEXT,
+    image TEXT
+);

--- a/modules/admin.py
+++ b/modules/admin.py
@@ -1,0 +1,59 @@
+from flask import render_template, request, redirect, url_for, flash
+from utils.db import get_db
+
+
+def admin_packs_list():
+    """Renderiza la lista de packs."""
+    conn = get_db()
+    packs = conn.execute('SELECT slug, name, description, price, image FROM packs').fetchall()
+    return render_template('admin_packs.html', packs=packs)
+
+
+def admin_packs_new():
+    conn = get_db()
+    if request.method == 'POST':
+        slug = request.form['slug'].strip()
+        name = request.form['name'].strip()
+        desc = request.form.get('description', '').strip()
+        price = request.form['price'].strip()
+        image = request.form.get('image', '').strip()
+        if not slug or not name:
+            flash('Slug y nombre son obligatorios')
+        else:
+            existing = conn.execute('SELECT 1 FROM packs WHERE slug=?', (slug,)).fetchone()
+            if existing:
+                flash('Slug ya existe')
+            else:
+                conn.execute(
+                    'INSERT INTO packs (slug, name, description, price, image) VALUES (?,?,?,?,?)',
+                    (slug, name, desc, price, image)
+                )
+                conn.commit()
+                return redirect(url_for('admin.admin_packs'))
+    return render_template('admin_pack_form.html', pack=None)
+
+
+def admin_packs_edit(slug):
+    conn = get_db()
+    pack = conn.execute('SELECT slug, name, description, price, image FROM packs WHERE slug=?', (slug,)).fetchone()
+    if not pack:
+        return redirect(url_for('admin.admin_packs'))
+    if request.method == 'POST':
+        name = request.form['name'].strip()
+        desc = request.form.get('description', '').strip()
+        price = request.form['price'].strip()
+        image = request.form.get('image', '').strip()
+        conn.execute(
+            'UPDATE packs SET name=?, description=?, price=?, image=? WHERE slug=?',
+            (name, desc, price, image, slug)
+        )
+        conn.commit()
+        return redirect(url_for('admin.admin_packs'))
+    return render_template('admin_pack_form.html', pack=pack)
+
+
+def admin_packs_delete(slug):
+    conn = get_db()
+    conn.execute('DELETE FROM packs WHERE slug=?', (slug,))
+    conn.commit()
+    return redirect(url_for('admin.admin_packs'))

--- a/static/style.css
+++ b/static/style.css
@@ -905,3 +905,26 @@ body.forum-new {
   border-radius: 1rem;
   background: #222;
 }
+
+/* Admin packs table */
+.admin-packs-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  background: #111;
+  color: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.admin-packs-table th,
+.admin-packs-table td {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #333;
+}
+.admin-packs-table th {
+  background: #222;
+}
+.admin-packs-table img {
+  width: 60px;
+  border-radius: 4px;
+}

--- a/templates/admin_pack_form.html
+++ b/templates/admin_pack_form.html
@@ -1,0 +1,13 @@
+{% extends 'admin/base.html' %}
+{% block title %}{{ 'Editar' if pack else 'Nuevo' }} Pack{% endblock %}
+{% block admin_content %}
+<h2>{{ 'Editar' if pack else 'Nuevo' }} Pack</h2>
+<form method="post">
+  <input type="text" name="slug" placeholder="Slug" value="{{ pack['slug'] if pack else '' }}" {% if pack %}readonly{% endif %} required class="form-control full-input">
+  <input type="text" name="name" placeholder="Nombre" value="{{ pack['name'] if pack else '' }}" required class="form-control full-input">
+  <textarea name="description" placeholder="Descripción" class="form-control full-input">{{ pack['description'] if pack else '' }}</textarea>
+  <input type="text" name="price" placeholder="Precio" value="{{ pack['price'] if pack else '' }}" required class="form-control full-input">
+  <input type="text" name="image" placeholder="Imagen" value="{{ pack['image'] if pack else '' }}" class="form-control full-input">
+  <button type="submit" class="btn btn-primary">Guardar</button>
+</form>
+{% endblock %}

--- a/templates/admin_packs.html
+++ b/templates/admin_packs.html
@@ -1,0 +1,35 @@
+{% extends 'admin/base.html' %}
+{% block title %}Packs{% endblock %}
+{% block admin_content %}
+<header class="header">
+  <h2>Packs</h2>
+  <a href="{{ url_for('admin.admin_packs_new') }}" class="btn btn-primary">+ Nuevo Pack</a>
+</header>
+<table class="admin-packs-table">
+  <thead>
+    <tr>
+      <th>Imagen</th>
+      <th>Slug</th>
+      <th>Nombre</th>
+      <th>Precio</th>
+      <th>Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for pack in packs %}
+    <tr>
+      <td><img src="{{ pack['image'] }}" alt="{{ pack['name'] }}" width="80"></td>
+      <td>{{ pack['slug'] }}</td>
+      <td>{{ pack['name'] }}</td>
+      <td>{{ pack['price'] }}</td>
+      <td>
+        <a class="btn btn-primary" href="{{ url_for('admin.admin_packs_edit', slug=pack['slug']) }}">Editar</a>
+        <form action="{{ url_for('admin.admin_packs_delete', slug=pack['slug']) }}" method="post" style="display:inline;">
+          <button type="submit" class="btn btn-danger" onclick="return confirm('¿Eliminar este pack?');">Eliminar</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Resumen
- ruta `/admin/packs` que usa `admin_packs_list`
- implementa módulo `modules/admin.py` con lógica CRUD
- templates de listado y formulario de packs
- esquema actualizado con tabla `packs`
- estilos para la tabla de packs

## Testing
- `pytest -q` *(falla: ModuleNotFoundError debido a dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_6875ca33cffc8325b34fbf0c8f93cde2