### PR TITLE
Fix admin blueprint routing

### DIFF
--- a/app.py
+++ b/app.py
@@ -155,39 +155,6 @@ def get_all_comments():
     return _cmt_mgr().get_all_comments()
 
 
-# ----- Admin Packs CRUD -----
-from modules.admin import (
-    admin_packs_list,
-    admin_packs_new,
-    admin_packs_edit,
-    admin_packs_delete,
-)
-from utils.security import admin_required
-
-
-@admin_bp.route('/packs')
-@admin_required
-def admin_packs():
-    return admin_packs_list()
-
-
-@admin_bp.route('/packs/new', methods=['GET', 'POST'])
-@admin_required
-def admin_packs_new_route():
-    return admin_packs_new()
-
-
-@admin_bp.route('/packs/<string:slug>/edit', methods=['GET', 'POST'])
-@admin_required
-def admin_packs_edit_route(slug):
-    return admin_packs_edit(slug)
-
-
-@admin_bp.route('/packs/<string:slug>/delete', methods=['POST'])
-@admin_required
-def admin_packs_delete_route(slug):
-    return admin_packs_delete(slug)
-
 # ------------- Forum routes (remain here) -------------
 
 @app.route('/forum')

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -4,6 +4,12 @@ from utils.auth import ensure_admin_user
 from services.project_manager import ProjectManager
 from services.comment_manager import CommentManager
 from utils.security import admin_required
+from modules.admin import (
+    admin_packs_list,
+    admin_packs_new,
+    admin_packs_edit,
+    admin_packs_delete,
+)
 
 # Blueprint with short name used for endpoint prefix
 admin_bp = Blueprint('admin', __name__)
@@ -134,3 +140,29 @@ def admin_users():
 @admin_bp.route('/comentarios')
 def admin_comments():
     return render_template('admin_comments.html')
+
+
+# ----- Admin Packs CRUD -----
+
+@admin_bp.route('/packs')
+@admin_required
+def admin_packs():
+    return admin_packs_list()
+
+
+@admin_bp.route('/packs/new', methods=['GET', 'POST'])
+@admin_required
+def admin_packs_new_route():
+    return admin_packs_new()
+
+
+@admin_bp.route('/packs/<string:slug>/edit', methods=['GET', 'POST'])
+@admin_required
+def admin_packs_edit_route(slug):
+    return admin_packs_edit(slug)
+
+
+@admin_bp.route('/packs/<string:slug>/delete', methods=['POST'])
+@admin_required
+def admin_packs_delete_route(slug):
+    return admin_packs_delete(slug)


### PR DESCRIPTION
## Summary
- moved admin pack routes into `routes/admin.py`
- removed post-registration route definitions in `app.py`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6875cceaec1c8325905a15f94052a24d