### PR TITLE
Agrega acceso a CRUD de Packs en el panel de admin

### DIFF
--- a/templates/admin/sidebar.html
+++ b/templates/admin/sidebar.html
@@ -6,5 +6,6 @@
     <a href="{{ url_for('admin.admin') }}" class="menu-item{% if request.endpoint == 'admin.admin' %} active{% endif %}">
       <i class="fa fa-chart-pie"></i> Dashboard
     </a>
+    <a href="{{ url_for('admin.packs_list') }}" class="menu-item{% if request.endpoint == 'admin.packs_list' %} active{% endif %}">Packs</a>
   </nav>
 </aside>


### PR DESCRIPTION
## Summary
- show sidebar in admin base
- add "Packs" link in admin sidebar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6875d649456c8325832558ca54f9c4ab