### PR TITLE
Add admin video upload modal and status controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,4 @@ NUEVO ENDPOINT: `/packs`
 2. La variable `GOOGLE_CREDS_JSON` debe ser JSON de una sola línea.
 3. Si prefieres Base64, crea `GOOGLE_CREDS_B64` y el código ya lo soporta.
 4. Usa `/status` para verificar que la app responde.
+Cada nota en el camino es eco de la bestia digital.

--- a/app.py
+++ b/app.py
@@ -135,6 +135,10 @@ def delete_video(project_id):
     _proj_mgr().delete_video(project_id)
 
 
+def update_status(project_id, status):
+    _proj_mgr().update_status(project_id, status)
+
+
 def get_projects_for_email(email):
     return _proj_mgr().get_projects_for_email(email)
 

--- a/services/project_manager.py
+++ b/services/project_manager.py
@@ -95,7 +95,7 @@ class ProjectManager:
         conn = self.db_conn()
         cur = conn.cursor()
         cur.execute(
-            'SELECT p.id,p.title,p.video_url,c.email, p.paid '
+            'SELECT p.id,p.title,p.video_url,c.email,p.paid,p.status '
             'FROM projects p JOIN clients c ON p.client_id=c.id'
         )
         rows = cur.fetchall()
@@ -108,5 +108,12 @@ class ProjectManager:
                 'video_url': r[2],
                 'client_email': r[3],
                 'paid': bool(r[4]),
+                'status': r[5],
             })
         return projects
+
+    def update_status(self, project_id: int, status: str) -> None:
+        conn = self.db_conn()
+        conn.execute('UPDATE projects SET status=? WHERE id=?', (status, project_id))
+        conn.commit()
+        conn.close()

--- a/static/css/admin_modern.css
+++ b/static/css/admin_modern.css
@@ -153,3 +153,27 @@ body {
     padding: 1rem;
   }
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+.modal.show { opacity: 1; pointer-events: auto; }
+.modal-content {
+  background: var(--bg-color);
+  padding: 1rem;
+  border-radius: var(--radius);
+  max-width: 500px;
+  width: 90%;
+}
+.status-form button { margin-right: .25rem; }

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -21,4 +21,16 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   }
+
+  var openBtn = document.getElementById('open-upload');
+  var modal = document.getElementById('upload-modal');
+  var closeBtn = modal ? modal.querySelector('.close-modal') : null;
+  if (openBtn && modal && closeBtn) {
+    openBtn.addEventListener('click', function () {
+      modal.classList.add('show');
+    });
+    closeBtn.addEventListener('click', function () {
+      modal.classList.remove('show');
+    });
+  }
 });

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -25,10 +25,10 @@
     </header>
 
   {% set stat_items = [
-     ('Proyectos',         stats.total),
-     ('Activos',           stats.active),
-     ('Completados',       stats.completed),
-     ('Pendientes',        stats.pending)
+     ('Proyectos',    stats.total),
+     ('En revisión',  stats.revision),
+     ('Finalizados',  stats.finalizado),
+     ('Pagados',      stats.pagado)
   ] %}
   <div class="stats-grid">
     {% for label, value in stat_items %}
@@ -39,13 +39,19 @@
     {% endfor %}
   </div>
 
-    <form class="project-form" action="{{ url_for('admin.admin_add_project') }}" method="post">
-      <input type="text" name="title" placeholder="Título" required>
-      <input type="text" name="category" placeholder="Categoría" required>
-      <input type="text" name="video_url" placeholder="URL" required>
-      <input type="email" name="client_email" placeholder="Cliente" required>
-      <button type="submit">Agregar</button>
-    </form>
+    <button id="open-upload" class="btn">Subir video</button>
+    <div id="upload-modal" class="modal">
+      <div class="modal-content">
+        <span class="close-modal">&times;</span>
+        <form class="project-form" action="{{ url_for('admin.admin_upload_project') }}" method="post" enctype="multipart/form-data">
+          <input type="text" name="title" placeholder="Título" required>
+          <input type="text" name="category" placeholder="Categoría" required>
+          <input type="file" name="video_file" accept="video/*" required>
+          <input type="email" name="client_email" placeholder="Cliente" required>
+          <button type="submit">Subir</button>
+        </form>
+      </div>
+    </div>
 
     {% for p in projects %}
       <div class="project-card">
@@ -61,6 +67,11 @@
           {% else %}
           <span>Pago activado</span>
           {% endif %}
+        </form>
+        <form action="{{ url_for('admin.admin_update_status', project_id=p.id) }}" method="post" class="status-form">
+          <button type="submit" name="status" value="revision" class="btn">En revisión</button>
+          <button type="submit" name="status" value="finalizado" class="btn">Finalizado</button>
+          <button type="submit" name="status" value="pagado" class="btn">Pagado</button>
         </form>
         <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();">
           <button type="submit" class="btn-danger">Eliminar Video</button>
@@ -90,5 +101,12 @@ function confirmDelete(){
   if(key!=='eliminar 2025'){alert('Clave incorrecta');return false;}
   return true;
 }
+
+document.getElementById('open-upload')?.addEventListener('click', () => {
+  document.getElementById('upload-modal').classList.add('show');
+});
+document.querySelector('#upload-modal .close-modal')?.addEventListener('click', () => {
+  document.getElementById('upload-modal').classList.remove('show');
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow admin to upload videos from modal window
- track project status as `revision`, `finalizado` or `pagado`
- provide buttons to change status per project
- add modal styles and JS handlers
- append README line continuing the story

## Testing
- `python -m py_compile routes/admin.py services/project_manager.py app.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6875d8081b4c8325836a2d2db78271a8