### PR TITLE
Mejora sidebar admin: espaciado, renombres y nuevas vistas Clientes/Comentarios

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -59,6 +59,26 @@ def admin():
                            open_projects=open_projects)
 
 
+@admin_bp.route('/projects')
+@admin_required
+def projects():
+    """Listar proyectos"""
+    mgr = _manager()
+    cmt = _comments()
+    projects = mgr.get_all_projects()
+    comments = cmt.get_all_comments()
+    stats = {
+        'total': len(projects),
+        'revision': sum(1 for p in projects if p.get('status') == 'revision'),
+        'finalizado': sum(1 for p in projects if p.get('status') == 'finalizado'),
+        'pagado': sum(1 for p in projects if p.get('status') == 'pagado')
+    }
+    open_projects = [p for p in projects if p.get('status') != 'finalizado']
+    return render_template('admin_panel.html', projects=projects,
+                           comments=comments, stats=stats,
+                           open_projects=open_projects)
+
+
 @admin_bp.route('/login', methods=['GET', 'POST'])
 def admin_login():
     if request.method == 'POST':
@@ -162,6 +182,12 @@ def admin_update_status(project_id):
 def admin_clients():
     return render_template('admin_clients.html')
 
+
+@admin_bp.route('/clients')
+def clients():
+    """Vista Clientes (en)"""
+    return render_template('admin/clients.html')
+
 @admin_bp.route('/usuarios')
 def admin_users():
     return render_template('admin_users.html')
@@ -169,6 +195,12 @@ def admin_users():
 @admin_bp.route('/comentarios')
 def admin_comments():
     return render_template('admin_comments.html')
+
+
+@admin_bp.route('/comments')
+def comments():
+    """Vista Comentarios (en)"""
+    return render_template('admin/comments.html')
 
 
 # ----- Admin Packs CRUD -----

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -33,10 +33,10 @@ h1, h2, h3, h4 {
   width: 260px;
   padding: 1rem;
   position: fixed;
-  top: 0;
+  top: 120px;
   bottom: 0;
   left: 0;
-  height: 100vh;
+  height: calc(100vh - 120px);
 }
 .sidebar .avatar img {
   width: 60px;

--- a/static/style.css
+++ b/static/style.css
@@ -912,3 +912,20 @@ body.forum-new {
 .admin-packs-table th,
 .admin-packs-table td { padding: .75rem; border:1px solid #333; }
 .admin-packs-table tr:hover { background: #222; }
+
+.sidebar-nav a {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: #ccc;
+  transition: background 0.2s, color 0.2s;
+}
+.sidebar-nav a.active,
+.sidebar-nav a:hover {
+  background: #333;
+  color: #fff;
+}
+.sidebar-nav {
+  padding-top: 4rem; /* deja espacio para el header */
+}

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -10,7 +10,9 @@
 
 {% block content %}
 <div class="app-container">
-  {% include 'admin/sidebar.html' %}
+  <div class="sidebar-container" style="margin-top: 4rem;">
+    {% include 'admin/sidebar.html' %}
+  </div>
   <div class="main-content">
     {% block admin_content %}{% endblock %}
   </div>

--- a/templates/admin/clients.html
+++ b/templates/admin/clients.html
@@ -1,0 +1,3 @@
+{% extends 'admin/base.html' %}
+{% block admin_content %}
+{% endblock %}

--- a/templates/admin/comments.html
+++ b/templates/admin/comments.html
@@ -1,0 +1,3 @@
+{% extends 'admin/base.html' %}
+{% block admin_content %}
+{% endblock %}

--- a/templates/admin/sidebar.html
+++ b/templates/admin/sidebar.html
@@ -2,10 +2,10 @@
   <div class="avatar">
     <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin" />
   </div>
-  <nav class="menu">
-    <a href="{{ url_for('admin.admin') }}" class="menu-item{% if request.endpoint == 'admin.admin' %} active{% endif %}">
-      <i class="fa fa-chart-pie"></i> Dashboard
-    </a>
-    <a href="{{ url_for('admin.packs_list') }}" class="menu-item{% if request.endpoint == 'admin.packs_list' %} active{% endif %}">Packs</a>
+  <nav class="sidebar-nav">
+    <a href="{{ url_for('admin.projects') }}" class="{% if request.path == url_for('admin.projects') %}active{% endif %}">Mis proyectos</a>
+    <a href="{{ url_for('admin.clients') }}" class="{% if request.path == url_for('admin.clients') %}active{% endif %}">Clientes</a>
+    <a href="{{ url_for('admin.admin_users') }}" class="{% if request.path == url_for('admin.admin_users') %}active{% endif %}">Usuarios</a>
+    <a href="{{ url_for('admin.comments') }}" class="{% if request.path == url_for('admin.comments') %}active{% endif %}">Comentarios</a>
   </nav>
 </aside>


### PR DESCRIPTION
- Sidebar movido hacia abajo para no solaparse con header.
- Dashboard eliminado, «Proyectos» renombrado a «Mis proyectos» con estado active.
- Añadidos enlaces y vistas básicas para Clientes y Comentarios.
- Estilos CSS actualizados para hover y active en sidebar.


------
https://chatgpt.com/codex/tasks/task_e_6875dc2c65c88325ab3912104b67915d