### PR TITLE
Update nav panel and motivational quotes

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -8,10 +8,10 @@ header.app-bar{
 }
 .app-bar .logo{
   font-family:'Inter',sans-serif;font-weight:800;letter-spacing:.04em;
-  font-size:clamp(2rem,4vw,5rem);line-height:1;color:#fff;text-decoration:none;
+  font-size:clamp(1.8rem,3vw,4rem);line-height:1;color:#fff;text-decoration:none;
   background:none !important;transition:font-size .3s;
 }
-.app-bar .logo:hover{background:none;font-size:clamp(2.2rem,4.4vw,5.4rem);}
+.app-bar .logo:hover{background:none;font-size:clamp(2rem,3.4vw,4.4rem);}
 .forum-link{
   margin-left:auto;
   background:var(--primary,#00D4B8);
@@ -31,9 +31,9 @@ header.app-bar{
   width:48px;height:6px;background:#fff;border-radius:3px;
   transition:all .3s;
 }
-#navToggle.open span:nth-child(1){transform:translateY(5px) rotate(45deg);}
+#navToggle.open span:nth-child(1){transform:translateY(14px) rotate(45deg);}
 #navToggle.open span:nth-child(2){opacity:0;}
-#navToggle.open span:nth-child(3){transform:translateY(-5px) rotate(-45deg);}
+#navToggle.open span:nth-child(3){transform:translateY(-14px) rotate(-45deg);}
 
 #navPanel{
   position:absolute;top:72px;left:0;width:100%;
@@ -62,3 +62,12 @@ header.app-bar{
 
 .primary{color:var(--accent);}
 .secondary{color:var(--primary);}
+
+/* Quote rotator in header */
+#quoteRotator{
+  margin:0 auto;
+  color:#A0AEC0;
+  font-size:clamp(1rem,2vw,1.2rem);
+  transition:opacity .4s ease;
+}
+#quoteRotator.hide{opacity:0;}

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,8 +1,32 @@
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('navToggle');
   const panel = document.getElementById('navPanel');
-  btn?.addEventListener('click', () => {
-    panel.classList.toggle('open');
-    btn.classList.toggle('open');
-  });
+  const rotator = document.getElementById('quoteRotator');
+
+  const togglePanel = () => {
+    const open = panel.classList.toggle('open');
+    btn.classList.toggle('open', open);
+    if (rotator) rotator.classList.toggle('hide', open);
+  };
+
+  btn?.addEventListener('click', togglePanel);
+
+  if (rotator) {
+    let current = rotator.textContent;
+    const updateQuote = text => {
+      rotator.style.opacity = 0;
+      setTimeout(() => {
+        rotator.textContent = text;
+        rotator.style.opacity = 1;
+      }, 400);
+    };
+    const fetchQuote = () => {
+      fetch('/api/random-quote')
+        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(d => { if (d.quote) current = d.quote; })
+        .catch(() => {})
+        .finally(() => updateQuote(current));
+    };
+    setInterval(fetchQuote, 6000);
+  }
 });

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -6,7 +6,9 @@
 
   <a class="logo" href="{{ url_for('client.home') }}">VERITÉ</a>
 
-  <a class="forum-link" href="{{ url_for('forum_index') }}">VFORUM</a>
+  <a class="forum-link" href="{{ url_for('admin.admin') }}">ADMIN</a>
+
+  <div id="quoteRotator">{{ get_random_quote() }}</div>
 
   <nav id="navPanel">
     <a href="{{ url_for('client.home') }}">Inicio</a>
@@ -14,7 +16,6 @@
     <a href="{{ url_for('client.services_page') }}">Services</a>
     <a href="{{ url_for('forum_index') }}">VForum</a>
     <a href="{{ url_for('client.academy') }}">Academia</a>
-    <a href="{{ url_for('client.dashboard') }}">Dashboard</a>
-    <a href="{{ url_for('admin.admin') }}">Admin</a>
+    <a href="{{ url_for('client.dashboard') }}">Mis proyectos</a>
   </nav>
 </header>

--- a/utils/quotes.py
+++ b/utils/quotes.py
@@ -1,13 +1,6 @@
 from random import choice
-
-_QUOTES = [
-    "La creatividad es inteligencia divirtiéndose.",
-    "El éxito es la suma de pequeños esfuerzos repetidos cada día.",
-    "Transforma tus ideas en realidad.",
-    "Cada proyecto es una oportunidad para crecer.",
-    "La constancia vence al talento cuando el talento no se esfuerza."
-]
+from modules.forum import INSPIRATIONAL_QUOTES
 
 def get_random_quote() -> str:
     """Devuelve una frase motivacional aleatoria."""
-    return choice(_QUOTES)
+    return choice(INSPIRATIONAL_QUOTES)


### PR DESCRIPTION
## Summary
- tweak nav button animation and logo size
- show inspirational quotes in header when menu closed
- move Admin link to header and rename Dashboard link
- reuse forum quotes for API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6875ef2460508325a1009563216d60fc