### PR TITLE
Adjust navbar and carousel timings

### DIFF
--- a/static/css/home_brutalista.css
+++ b/static/css/home_brutalista.css
@@ -226,6 +226,7 @@ body {
 .join-copy      { max-width:42rem; margin:1rem auto 3rem; color:#cbd5e0; }
 
 .alt-font       { font-family:"Bebas Neue", "Inter", sans-serif; }
+#dynamic-word   { font-size:clamp(3rem,8vw,5.6rem); display:block; }
 @keyframes fadeIO {
     0%   { opacity:0; filter:blur(2px);}
     10%  { opacity:1; filter:none; }

--- a/static/css/navbar_hamburger.css
+++ b/static/css/navbar_hamburger.css
@@ -65,5 +65,5 @@
   text-align:center;
   color:#A0AEC0;
   margin-top:20px;
-  transition:opacity 0.4s ease;
+  transition:opacity 1.8s ease;
 }

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -68,6 +68,6 @@ header.app-bar{
   margin:0 auto;
   color:#A0AEC0;
   font-size:clamp(1rem,2vw,1.2rem);
-  transition:opacity .4s ease;
+  transition:opacity 1.8s ease;
 }
 #quoteRotator.hide{opacity:0;}

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
       setTimeout(() => {
         rotator.textContent = text;
         rotator.style.opacity = 1;
-      }, 400);
+      }, 1800);
     };
     const fetchQuote = () => {
       fetch('/api/random-quote')
@@ -27,6 +27,6 @@ document.addEventListener('DOMContentLoaded', () => {
         .catch(() => {})
         .finally(() => updateQuote(current));
     };
-    setInterval(fetchQuote, 6000);
+    setInterval(fetchQuote, 8000);
   }
 });

--- a/static/js/navbar_hamburger.js
+++ b/static/js/navbar_hamburger.js
@@ -39,7 +39,7 @@
       setTimeout(() => {
         rotator.textContent = text;
         rotator.style.opacity = 1;
-      }, 400);
+      }, 1800);
     };
 
     const fetchQuote = () => {
@@ -50,6 +50,6 @@
         .finally(() => updateQuote(current));
     };
 
-    setInterval(fetchQuote, 6000);
+    setInterval(fetchQuote, 8000);
   }
 })();

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -6,8 +6,6 @@
 
   <a class="logo" href="{{ url_for('client.home') }}">VERITÉ</a>
 
-  <a class="forum-link" href="{{ url_for('admin.admin') }}">ADMIN</a>
-
   <div id="quoteRotator">{{ get_random_quote() }}</div>
 
   <nav id="navPanel">


### PR DESCRIPTION
## Summary
- remove Admin link from header
- make quote rotator fade last longer
- extend quote display time by 2 seconds
- enlarge professions list text size

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68763605e9dc8325a011de449833d2cb