### PR TITLE
Add Firestore setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,4 +165,33 @@ NUEVO ENDPOINT: `/packs`
 3. Si prefieres Base64, crea `GOOGLE_CREDS_B64` y el código ya lo soporta.
 4. Usa `/status` para verificar que la app responde.
 Cada nota en el camino es eco de la bestia digital.
+
+## Configuración de Firebase Firestore
+
+1. Crea un proyecto en Firebase y descarga `serviceAccountKey.json`.
+2. Guarda `serviceAccountKey.json` en la raíz del proyecto.
+3. Establece la variable de entorno `GOOGLE_APPLICATION_CREDENTIALS`:
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/serviceAccountKey.json"
+   ```
+   o en Windows PowerShell:
+   ```powershell
+   $Env:GOOGLE_APPLICATION_CREDENTIALS = "$(pwd)\serviceAccountKey.json"
+   ```
+4. Ejecuta el script de inicialización:
+   ```bash
+   python scripts/firebase_init.py
+   ```
+
+Para verificar la conexión a Firestore:
+```bash
+python - << 'EOF'
+from firebase_admin import firestore, initialize_app, credentials
+initialize_app(credentials.Certificate('serviceAccountKey.json'))
+db = firestore.client()
+print(db.collections())
+EOF
+```
+
 Su resonancia guia a futuras expediciones creativas.
+Las rutas que se dibujan llevan a horizontes inesperados.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gunicorn>=21.0
 google-auth>=2.0
 google-api-python-client>=2.97
 cachetools>=5
+firebase-admin

--- a/scripts/firebase_init.py
+++ b/scripts/firebase_init.py
@@ -1,0 +1,7 @@
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+cred = credentials.Certificate('serviceAccountKey.json')
+app = firebase_admin.initialize_app(cred)
+
+db = firestore.client()


### PR DESCRIPTION
## Summary
- install `firebase-admin`
- add `scripts/firebase_init.py` for Firestore initialization
- document Firestore setup and test instructions
- extend the ongoing story in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=3.0)*
- `pytest -q` *(fails to collect tests: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6876c5ee5d608325a04f5a592739d6f7