### PR TITLE
Improve admin avatar styling

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -38,12 +38,27 @@ h1, h2, h3, h4 {
   left: 0;
   height: calc(100vh - 120px);
 }
+.sidebar .avatar {
+  text-align: center;
+  margin: 20px auto;
+}
 .sidebar .avatar img {
-  width: 60px;
-  height: 60px;
+  width: 70px;
+  height: 70px;
   border-radius: 50%;
+  border: 2px solid var(--accent-blue);
   display: block;
-  margin: 0 auto 1rem;
+  margin: 0 auto;
+  object-fit: cover;
+}
+
+.sidebar .avatar-label {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-align: center;
+  display: block;
+  margin-bottom: 20px;
 }
 .menu .menu-item {
   display: block;

--- a/static/css/admin_improved.css
+++ b/static/css/admin_improved.css
@@ -57,16 +57,25 @@
 /* Avatar en sidebar */
 .sidebar .avatar {
     text-align: center;
-    margin-bottom: 2rem;
+    margin: 20px auto;
 }
 
 .sidebar .avatar img {
-    width: 80px;
-    height: 80px;
+    width: 70px;
+    height: 70px;
     border-radius: 50%;
-    border: 3px solid var(--admin-primary);
-    padding: 3px;
+    border: 2px solid var(--admin-accent);
+    display: block;
+    margin: 0 auto;
+    object-fit: cover;
     background: var(--admin-bg-3);
+}
+
+.sidebar .avatar-label {
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--admin-text-muted);
+    text-align: center;
 }
 
 /* Navegación del sidebar */

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -10,6 +10,7 @@
   <aside class="sidebar">
     <div class="avatar">
       <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin">
+      <span class="avatar-label">Admin</span>
     </div>
     <nav class="menu"></nav>
   </aside>

--- a/templates/admin/sidebar.html
+++ b/templates/admin/sidebar.html
@@ -1,6 +1,7 @@
 <aside class="sidebar">
   <div class="avatar">
     <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin" />
+    <span class="avatar-label">Admin</span>
   </div>
   <div class="sidebar-nav">
     <button data-section="proyectos">Mis proyectos</button>

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -10,6 +10,7 @@
     <aside class="sidebar">
       <div class="avatar">
         <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin">
+        <span class="avatar-label">Admin</span>
       </div>
       <div class="sidebar-nav">
         <button data-section="proyectos" class="active">Proyectos</button>


### PR DESCRIPTION
## Summary
- refine admin avatar CSS in both admin themes
- center avatar and add subtle label
- update admin templates with new avatar label

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6876d0d0670c83259b2c594e9d7b78f4