### PR TITLE
Fix admin avatar centering

### DIFF
--- a/static/css/admin_improved.css
+++ b/static/css/admin_improved.css
@@ -55,9 +55,20 @@
 }
 
 /* Avatar en sidebar */
-.sidebar .avatar {
+.sidebar .avatar-wrapper {
     text-align: center;
     margin: 20px auto;
+}
+
+.sidebar .avatar {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background: var(--admin-bg-3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
 }
 
 .sidebar .avatar img {
@@ -65,13 +76,11 @@
     height: 70px;
     border-radius: 50%;
     border: 2px solid var(--admin-accent);
-    display: block;
-    margin: 0 auto;
     object-fit: cover;
-    background: var(--admin-bg-3);
 }
 
 .sidebar .avatar-label {
+    display: block;
     margin-top: 0.5rem;
     font-size: 0.875rem;
     color: var(--admin-text-muted);

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -8,8 +8,10 @@
 {% block content %}
 <div class="app-container">
   <aside class="sidebar">
-    <div class="avatar">
-      <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin">
+    <div class="avatar-wrapper">
+      <div class="avatar">
+        <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin">
+      </div>
       <span class="avatar-label">Admin</span>
     </div>
     <nav class="menu"></nav>

--- a/templates/admin/sidebar.html
+++ b/templates/admin/sidebar.html
@@ -1,6 +1,8 @@
 <aside class="sidebar">
-  <div class="avatar">
-    <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin" />
+  <div class="avatar-wrapper">
+    <div class="avatar">
+      <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin" />
+    </div>
     <span class="avatar-label">Admin</span>
   </div>
   <div class="sidebar-nav">

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -8,8 +8,10 @@
 <div class="admin-panel">
   <div class="dashboard-container">
     <aside class="sidebar">
-      <div class="avatar">
-        <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin">
+      <div class="avatar-wrapper">
+        <div class="avatar">
+          <img src="{{ url_for('static', filename='img/avatar.png') }}" alt="admin">
+        </div>
         <span class="avatar-label">Admin</span>
       </div>
       <div class="sidebar-nav">


### PR DESCRIPTION
## Summary
- align admin avatar circle by introducing `.avatar-wrapper`
- update CSS to center avatar image inside the circle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*
- `pip install -q -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6876d68c46f88325832c0b613abcccb9