### PR TITLE
Add Firebase Firestore integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Verificar Firestore
+        run: |
+          export GOOGLE_APPLICATION_CREDENTIALS=serviceAccountKey.json
+          python scripts/firebase_init.py
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ La brisa arrastra nuestras historias hacia nuevos horizontes.
 Cada paso resuena en los ecos digitales de nuestro viaje.
 
 Nuestros relatos se entretejen con la luz de cada proyecto completado.
+La sinfonia de nuestra colaboracion resuena en cada rincon digital.
 ──────────────────────────────────────────────
 
 📜 MANIFIESTO DE EEVI
@@ -166,32 +167,24 @@ NUEVO ENDPOINT: `/packs`
 4. Usa `/status` para verificar que la app responde.
 Cada nota en el camino es eco de la bestia digital.
 
-## Configuración de Firebase Firestore
+## Configuración Firebase Firestore
 
-1. Crea un proyecto en Firebase y descarga `serviceAccountKey.json`.
-2. Guarda `serviceAccountKey.json` en la raíz del proyecto.
-3. Establece la variable de entorno `GOOGLE_APPLICATION_CREDENTIALS`:
-   ```bash
-   export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/serviceAccountKey.json"
-   ```
-   o en Windows PowerShell:
-   ```powershell
-   $Env:GOOGLE_APPLICATION_CREDENTIALS = "$(pwd)\serviceAccountKey.json"
-   ```
-4. Ejecuta el script de inicialización:
-   ```bash
-   python scripts/firebase_init.py
-   ```
+* Crea la base de datos en Firebase Console (Firestore → Modo nativo).
+* Descarga y coloca `serviceAccountKey.json` en la raíz del proyecto.
+* Define la variable de entorno:
 
-Para verificar la conexión a Firestore:
-```bash
-python - << 'EOF'
-from firebase_admin import firestore, initialize_app, credentials
-initialize_app(credentials.Certificate('serviceAccountKey.json'))
-db = firestore.client()
-print(db.collections())
-EOF
-```
+  * Linux/macOS:
+
+    ```bash
+    export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/serviceAccountKey.json"
+    ```
+  * Windows PowerShell:
+
+    ```powershell
+    $Env:GOOGLE_APPLICATION_CREDENTIALS = "$(pwd)\serviceAccountKey.json"
+    ```
+* Instala dependencias: `pip install -r requirements.txt`
+* Probar inicialización: `python scripts/firebase_init.py`
 
 Su resonancia guia a futuras expediciones creativas.
 Las rutas que se dibujan llevan a horizontes inesperados.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ import os
 import re
 import sqlite3
 import time
-import json
 from werkzeug.security import generate_password_hash
 from flask import (
     Flask, render_template, request, redirect, jsonify,
@@ -12,11 +11,14 @@ from jinja2 import TemplateNotFound
 
 from firebase_admin import credentials, initialize_app, firestore
 
-# Carga el JSON desde la variable
-creds_dict = json.loads(os.getenv("GOOGLE_CREDS_JSON"))
-cred = credentials.Certificate(creds_dict)
-initialize_app(cred)
+# Cargar credenciales desde env var o archivo local
+cred_path = os.getenv('GOOGLE_APPLICATION_CREDENTIALS', 'serviceAccountKey.json')
+if not os.path.isfile(cred_path):
+    raise RuntimeError(f"Credenciales no encontradas: {cred_path}")
 
+# Inicializar Firebase Admin y obtener cliente Firestore
+cred = credentials.Certificate(cred_path)
+initialize_app(cred)
 db = firestore.client()
 
 from config import config

--- a/render.yaml
+++ b/render.yaml
@@ -3,8 +3,8 @@ services:
     name: eevi-verite
     env: python
     plan: free
-    buildCommand: ""
-    startCommand: "./scripts/start.sh"
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn app:app --bind 0.0.0.0:$PORT
     envVars:
       - key: PYTHON_VERSION
         value: 3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ gunicorn>=21.0
 google-auth>=2.0
 google-api-python-client>=2.97
 cachetools>=5
-firebase-admin
+firebase-admin>=6.0.0

--- a/scripts/firebase_init.py
+++ b/scripts/firebase_init.py
@@ -1,7 +1,9 @@
-import firebase_admin
-from firebase_admin import credentials, firestore
+import os
+from firebase_admin import credentials, initialize_app, firestore
 
-cred = credentials.Certificate('serviceAccountKey.json')
-app = firebase_admin.initialize_app(cred)
+cred_path = os.getenv('GOOGLE_APPLICATION_CREDENTIALS', 'serviceAccountKey.json')
+if not os.path.isfile(cred_path):
+    raise RuntimeError(f"Archivo no encontrado: {cred_path}")
 
-db = firestore.client()
+initialize_app(credentials.Certificate(cred_path))
+print('✅ Firestore inicializado correctamente')


### PR DESCRIPTION
## Summary
- integrate firebase-admin setup in `app.py`
- version pin firebase-admin to >=6.0.0
- add helper script for Firestore initialization
- describe Firestore setup in README
- create GitHub Actions workflow with Firestore check
- update Render deployment commands
- extend project narrative in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68773b28a2608325a8bbcbcaec399204