### PR TITLE
Switch forum routes to Firestore

### DIFF
--- a/routes/client.py
+++ b/routes/client.py
@@ -54,9 +54,14 @@ def packs():
 
 @client_bp.route('/', methods=['GET'])
 def home():
-    from modules import forum as forum_db
+    from firebase_admin import firestore
     from utils.drive_previews import fetch_previews
-    latest = forum_db.get_latest_topic()
+    fs_client = firestore.client()
+    docs = fs_client.collection('foro').order_by('timestamp', direction=firestore.Query.DESCENDING).limit(1).stream()
+    latest = None
+    for d in docs:
+        latest = {**d.to_dict(), 'id': d.id}
+        break
     packs = get_all_packs()
     services = get_all_services()
     previews = fetch_previews()

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -1,0 +1,5 @@
+<ul>
+{% for tema in temas %}
+  <li><a href="/forum/{{ tema.id }}">{{ tema.titulo }}</a></li>
+{% endfor %}
+</ul>

--- a/templates/topic.html
+++ b/templates/topic.html
@@ -1,0 +1,3 @@
+<h1>{{ tema.titulo }}</h1>
+<p>{{ tema.contenido }}</p>
+<small>Por {{ tema.autor }} el {{ tema.timestamp }}</small>


### PR DESCRIPTION
## Summary
- use Firestore client instead of the old forum DB
- create Firestore-based forum routes
- fetch latest forum topic from Firestore on the home page
- add simple forum templates

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68773e886d3c8325bbd2210908f7baf2