### PR TITLE
Fix Firestore initialization and pin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ gunicorn>=21.0
 google-auth>=2.0
 google-api-python-client>=2.97
 cachetools>=5
-firebase-admin>=6.0.0
+firebase-admin==6.4.0
+google-cloud-firestore==2.14.0


### PR DESCRIPTION
## Summary
- ensure Firestore initialization uses `firebase_admin._apps`
- fallback credential path for local dev
- pin `firebase-admin` and `google-cloud-firestore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*
- `flake8 src/app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877bf3298cc83258cf02b3cb7cba0e6