### PR TITLE
Fix header forum link

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -12,7 +12,7 @@
     <a href="{{ url_for('client.home') }}">Inicio</a>
     <a href="{{ url_for('client.packs') }}">Packs</a>
     <a href="{{ url_for('client.services_page') }}">Services</a>
-    <a href="{{ url_for('forum_index') }}">VForum</a>
+    <a href="{{ url_for('list_forum') }}">VForum</a>
     <a href="{{ url_for('client.academy') }}">Academia</a>
     <a href="{{ url_for('client.dashboard') }}">Mis proyectos</a>
   </nav>


### PR DESCRIPTION
## Summary
- fix VForum link in header template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for firebase_admin and app)*

------
https://chatgpt.com/codex/tasks/task_e_6877ed6bca948325ae74f710eb791354