### PR TITLE
Fix forum link target in templates

### DIFF
--- a/templates/forum_detail.html
+++ b/templates/forum_detail.html
@@ -10,7 +10,7 @@
         <div class="topic-meta-text">{{ topic.created_at.strftime('%d %b %Y – %H:%M') }}</div>
       </div>
     </div>
-    <a class="btn-secondary" href="{{ url_for('forum_index') }}">Volver al Foro</a>
+    <a class="btn-secondary" href="{{ url_for('list_forum') }}">Volver al Foro</a>
   </div>
   <div class="topic-content">{{ topic.description }}</div>
   {% if show_delete %}

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -5,7 +5,7 @@
 {% block content %}
   {% if topic %}
   <div class="forum-topic-container">
-    <button onclick="window.location.href='{{ url_for('forum_index') }}'" class="back-btn">← Volver al foro</button>
+    <button onclick="window.location.href='{{ url_for('list_forum') }}'" class="back-btn">← Volver al foro</button>
     <h1 class="topic-title">{{ topic.title }}</h1>
     <p class="topic-meta">Categoría: {{ topic.category }} • {{ topic.created_at.strftime('%d %b %Y, %H:%M') }}</p>
     <div class="topic-body">{{ topic.description }}</div>
@@ -31,7 +31,7 @@
   </div>
   {% else %}
   <div class="alert alert-warning">
-    No encontramos ese tema. <a href="{{ url_for('forum_index') }}">Volver al foro</a>
+    No encontramos ese tema. <a href="{{ url_for('list_forum') }}">Volver al foro</a>
   </div>
   {% endif %}
 {% endblock %}

--- a/templates/forum_topic_view.html
+++ b/templates/forum_topic_view.html
@@ -5,7 +5,7 @@
 {% block content %}
   {% if topic %}
   <div class="forum-topic-container">
-    <button onclick="window.location.href='{{ url_for('forum_index') }}'" class="back-btn">← Volver al foro</button>
+    <button onclick="window.location.href='{{ url_for('list_forum') }}'" class="back-btn">← Volver al foro</button>
     <h1 class="topic-title">{{ topic.title }}</h1>
     <p class="topic-meta">Categoría: {{ topic.category }} • {{ topic.created_at.strftime('%d %b %Y, %H:%M') }}</p>
     <div class="topic-body">{{ topic.description }}</div>
@@ -29,7 +29,7 @@
   </div>
   {% else %}
   <div class="alert alert-warning">
-    No encontramos ese tema. <a href="{{ url_for('forum_index') }}">Volver al foro</a>
+    No encontramos ese tema. <a href="{{ url_for('list_forum') }}">Volver al foro</a>
   </div>
   {% endif %}
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -23,7 +23,7 @@
            <a href="{{ url_for('client.packs') }}" class="btn btn-primary">
                🎧 Explorar Packs
            </a>
-           <a href="{{ url_for('forum_index') }}" class="btn btn-secondary">
+           <a href="{{ url_for('list_forum') }}" class="btn btn-secondary">
                💬 Comunidad
            </a>
        </div>


### PR DESCRIPTION
## Summary
- fix broken forum links in templates by swapping `forum_index` for `list_forum`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*

------
https://chatgpt.com/codex/tasks/task_e_6877ef58bc608325b8301d4ec10d3211