### PR TITLE
Ensure forum categories helper exists

### DIFF
--- a/modules/forum.py
+++ b/modules/forum.py
@@ -406,3 +406,21 @@ def delete_topic_by_id(topic_id: int) -> None:
     cur.execute('DELETE FROM topics WHERE id=?', (topic_id,))
     conn.commit()
     conn.close()
+
+
+def get_categories() -> List[str]:
+    """Devuelve la lista de categorías predefinidas."""
+    return [
+        "Grabación en vivo",
+        "Diseño sonoro",
+        "Foley y efectos",
+        "Edición de vídeo",
+        "Edición de audio",
+        "Mezcla y masterización",
+        "Micrófonos y equipamiento",
+        "Workflows DAW y plugins",
+        "Ambientes y field recording",
+        "Postproducción",
+        "Formatos y codecs",
+        "Consejos de producción",
+    ]


### PR DESCRIPTION
## Summary
- add a definitive `get_categories` function at the end of `modules/forum.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68788d30dc608325a15b9814c4d9c905