### PR TITLE
Fix forum_new duplication

### DIFF
--- a/app.py
+++ b/app.py
@@ -319,19 +319,22 @@ if __name__ == '__main__':
 # Agregar estas rutas a tu app.py para el foro moderno
 
 @app.route('/forum/new', methods=['GET', 'POST'])
-def forum_new():
+def create_new_forum():
     """Crear nuevo tema en el foro"""
     if request.method == 'GET':
         categories = get_categories()
         return render_template('forum_new.html', categories=categories)
-    
+
     try:
         payload = request.form or request.json
+        titulo = payload.get('titulo') or payload.get('title')
+        contenido = payload.get('contenido') or payload.get('description')
+        autor = payload.get('autor') or payload.get('author', 'Anónimo')
         fs_client.collection('foro').add({
-            'titulo': payload['title'],
-            'contenido': payload['description'],
-            'category': payload['category'],
-            'autor': payload.get('autor', 'Anónimo'),
+            'titulo': titulo,
+            'contenido': contenido,
+            'category': payload.get('category', ''),
+            'autor': autor,
             'timestamp': firestore.SERVER_TIMESTAMP,
             'votes': 0
         })

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -33,7 +33,7 @@
 
             <!-- Formulario Nuevo Tema -->
             <div class="new-topic-form" id="newTopicForm">
-                <form id="topicForm" action="{{ url_for('forum_new') }}" method="post">
+                <form id="topicForm" action="{{ url_for('create_new_forum') }}" method="post">
             <div class="form-group">
                 <label class="form-label" for="authorName">Nombre:</label>
                 <input type="text" id="authorName" name="autor" class="form-input" required>

--- a/templates/forum_index.html
+++ b/templates/forum_index.html
@@ -10,7 +10,7 @@
   {% endfor %}
 </section>
 <div class="sticky-new-topic top">
-  <a href="{{ url_for('forum_new') }}" class="btn-new-topic">+ Nuevo Tema</a>
+  <a href="{{ url_for('create_new_forum') }}" class="btn-new-topic">+ Nuevo Tema</a>
 </div>
 {% if topics %}
 <div class="topic-list">

--- a/templates/forum_new.html
+++ b/templates/forum_new.html
@@ -6,7 +6,7 @@
 <div class="forum-new-container">
   <h1 class="section-title">CREAR NUEVO TEMA</h1>
   <p class="section-desc">Comparte tu reto audiovisual y colabora con la comunidad VFORUM.</p>
-  <form action="{{ url_for('forum_new') }}" method="post" enctype="multipart/form-data">
+  <form action="{{ url_for('create_new_forum') }}" method="post" enctype="multipart/form-data">
     <label for="title">Título</label>
     <input id="title" name="title" type="text" required>
 


### PR DESCRIPTION
## Summary
- rename `forum_new` endpoint to `create_new_forum`
- update forum templates to reference the new route
- allow the new endpoint to accept both old and new field names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*

------
https://chatgpt.com/codex/tasks/task_e_68789bf8aebc832595f7bba6ab318641