### PR TITLE
Use env JSON credentials for Firestore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: pip install -r requirements.txt
       - name: Verificar Firestore
         run: |
-          export GOOGLE_APPLICATION_CREDENTIALS=serviceAccountKey.json
+          export GOOGLE_APPLICATION_CREDENTIALS_JSON="$(cat serviceAccountKey.json)"
           python scripts/firebase_init.py
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -171,19 +171,11 @@ Cada nota en el camino es eco de la bestia digital.
 ## Configuración Firebase Firestore
 
 * Crea la base de datos en Firebase Console (Firestore → Modo nativo).
-* Descarga y coloca `serviceAccountKey.json` en la raíz del proyecto.
-* Define la variable de entorno:
+* Obtén el JSON de tu clave de servicio y asígnalo a la variable `GOOGLE_APPLICATION_CREDENTIALS_JSON`:
 
-  * Linux/macOS:
-
-    ```bash
-    export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/serviceAccountKey.json"
-    ```
-  * Windows PowerShell:
-
-    ```powershell
-    $Env:GOOGLE_APPLICATION_CREDENTIALS = "$(pwd)\serviceAccountKey.json"
-    ```
+  ```bash
+  export GOOGLE_APPLICATION_CREDENTIALS_JSON='{"type": "service_account", ...}'
+  ```
 * Instala dependencias: `pip install -r requirements.txt`
 * Probar inicialización: `python scripts/firebase_init.py`
 

--- a/app.py
+++ b/app.py
@@ -3,9 +3,8 @@ import re
 import sqlite3
 import time
 import datetime
-import firebase_admin
 from google.cloud import firestore
-fs_client = firestore.Client()
+from utils.firestore_client import get_fs_client
 from werkzeug.security import generate_password_hash
 from flask import (
     Flask, render_template, request, redirect, jsonify,
@@ -13,7 +12,6 @@ from flask import (
 )
 from jinja2 import TemplateNotFound
 
-from firebase_admin import credentials, firestore as fs, exceptions, initialize_app
 from google.api_core.exceptions import GoogleAPICallError
 from utils.template_filters import register_filters
 
@@ -47,9 +45,7 @@ def create_app():
 
 app = create_app()
 
-cred = credentials.Certificate('serviceAccountKey.json')
-initialize_app(cred)
-fs_client = firestore.client()
+fs_client = get_fs_client()
 foro_ref = fs_client.collection('foro')
 
 

--- a/routes/client.py
+++ b/routes/client.py
@@ -55,9 +55,10 @@ def packs():
 
 @client_bp.route('/', methods=['GET'])
 def home():
-    from firebase_admin import firestore
+    from google.cloud import firestore
     from utils.drive_previews import fetch_previews
-    fs_client = firestore.client()
+    from utils.firestore_client import get_fs_client
+    fs_client = get_fs_client()
     try:
         docs = (
             fs_client.collection('foro')

--- a/scripts/check_firestore.py
+++ b/scripts/check_firestore.py
@@ -1,13 +1,18 @@
 import os, json, sys
-from firebase_admin import credentials, initialize_app, firestore
+from google.cloud import firestore
+from google.oauth2 import service_account
 
-# Carga credenciales
-path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "serviceAccountKey.json")
-cred = credentials.Certificate(path)
-initialize_app(cred)
+credentials_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+if credentials_json is None:
+    raise RuntimeError(
+        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
+
+credentials_dict = json.loads(credentials_json)
+credentials = service_account.Credentials.from_service_account_info(credentials_dict)
+db = firestore.Client(credentials=credentials, project=credentials.project_id)
 
 # Intenta leer las colecciones
-db = firestore.client()
 cols = db.collections()
 print("Colecciones en Firestore:")
 for c in cols:

--- a/scripts/firebase_init.py
+++ b/scripts/firebase_init.py
@@ -1,9 +1,16 @@
 import os
-from firebase_admin import credentials, initialize_app, firestore
+import json
+from google.cloud import firestore
+from google.oauth2 import service_account
 
-cred_path = os.getenv('GOOGLE_APPLICATION_CREDENTIALS', 'serviceAccountKey.json')
-if not os.path.isfile(cred_path):
-    raise RuntimeError(f"Archivo no encontrado: {cred_path}")
+credentials_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+if credentials_json is None:
+    raise RuntimeError(
+        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
 
-initialize_app(credentials.Certificate(cred_path))
-print('✅ Firestore inicializado correctamente')
+credentials_dict = json.loads(credentials_json)
+credentials = service_account.Credentials.from_service_account_info(credentials_dict)
+
+firestore.Client(credentials=credentials, project=credentials.project_id)
+print("✅ Firestore inicializado correctamente")

--- a/utils/firestore_client.py
+++ b/utils/firestore_client.py
@@ -1,0 +1,19 @@
+import functools
+import json
+import os
+from google.cloud import firestore
+from google.oauth2 import service_account
+
+@functools.lru_cache(maxsize=1)
+def get_fs_client():
+    """Return a cached Firestore client using credentials from env."""
+    credentials_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+    if credentials_json is None:
+        raise RuntimeError(
+            "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+        )
+    credentials_dict = json.loads(credentials_json)
+    credentials = service_account.Credentials.from_service_account_info(
+        credentials_dict
+    )
+    return firestore.Client(credentials=credentials, project=credentials.project_id)


### PR DESCRIPTION
## Summary
- centralize Firestore connection in `utils/firestore_client.py`
- update application and scripts to load credentials from `GOOGLE_APPLICATION_CREDENTIALS_JSON`
- adjust CI workflow and documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6878a43e8688832594043c8c4e93337e