### PR TITLE
Implement forum responder endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,4 @@ Su resonancia guia a futuras expediciones creativas.
 Las rutas que se dibujan llevan a horizontes inesperados.
 Los ecos del viaje transforman cada espacio en una oportunidad.
 El mañana se escribe con la tinta de nuestras colaboraciones.
+Cada encuentro aviva el fuego que ilumina nuestro sendero digital.

--- a/app.py
+++ b/app.py
@@ -320,6 +320,29 @@ def forum_reply(topic_id):
         raise
 
 
+@app.route('/forum/<string:post_id>/responder', methods=['POST'])
+def responder(post_id):
+    """Guardar una respuesta en la subcolección 'respuestas' de un post"""
+    try:
+        contenido = request.form.get('respuesta') or (request.json or {}).get('respuesta')
+        if not contenido:
+            return jsonify({'error': 'La respuesta no puede estar vacía'}), 400
+
+        respuesta_data = {
+            'contenido': contenido,
+            'fecha_creacion': datetime.datetime.utcnow(),
+            'autor': 'Anónimo'
+        }
+
+        fs_client.collection('foro').document(post_id).collection('respuestas').add(respuesta_data)
+
+        return jsonify({'success': True, 'mensaje': 'Respuesta guardada correctamente'}), 200
+
+    except Exception as e:
+        print(f'Error al guardar respuesta: {e}')
+        return jsonify({'error': str(e)}), 500
+
+
 # Funciones helper para el template
 @app.template_filter('truncate_words')
 def truncate_words(text, count=10):


### PR DESCRIPTION
## Summary
- add new forum responder route to save replies in Firestore
- extend README story with another line

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'firebase_admin')*

------
https://chatgpt.com/codex/tasks/task_e_6878a4a7b9308325a5dd01f40229aa28