### PR TITLE
Update Firestore init via env JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: pip install -r requirements.txt
       - name: Verificar Firestore
         run: |
-          export GOOGLE_APPLICATION_CREDENTIALS=serviceAccountKey.json
+          export GOOGLE_APPLICATION_CREDENTIALS_JSON="$(cat serviceAccountKey.json)"
           python scripts/firebase_init.py
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -172,17 +172,17 @@ Cada nota en el camino es eco de la bestia digital.
 
 * Crea la base de datos en Firebase Console (Firestore → Modo nativo).
 * Descarga y coloca `serviceAccountKey.json` en la raíz del proyecto.
-* Define la variable de entorno:
+* Define la variable de entorno con el contenido del archivo de credenciales:
 
   * Linux/macOS:
 
     ```bash
-    export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/serviceAccountKey.json"
+    export GOOGLE_APPLICATION_CREDENTIALS_JSON="$(cat serviceAccountKey.json)"
     ```
   * Windows PowerShell:
 
     ```powershell
-    $Env:GOOGLE_APPLICATION_CREDENTIALS = "$(pwd)\serviceAccountKey.json"
+    $Env:GOOGLE_APPLICATION_CREDENTIALS_JSON = Get-Content serviceAccountKey.json -Raw
     ```
 * Instala dependencias: `pip install -r requirements.txt`
 * Probar inicialización: `python scripts/firebase_init.py`

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import re
 import sqlite3
 import time
 import datetime
+import json
 import firebase_admin
 from google.cloud import firestore
 from werkzeug.security import generate_password_hash
@@ -46,10 +47,25 @@ def create_app():
 
 app = create_app()
 
-cred = credentials.Certificate('serviceAccountKey.json')
-initialize_app(cred)
-fs_client = firestore.Client()
-foro_ref = fs_client.collection('foro')
+# --- Firebase initialization for Render ---
+firebase_creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+if not firebase_creds_json:
+    raise Exception(
+        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
+cred_dict = json.loads(firebase_creds_json)
+cred = credentials.Certificate(cred_dict)
+if not firebase_admin._apps:
+    firebase_admin.initialize_app(cred)
+
+fs_client = firestore.client()
+foro_ref = fs_client.collection("foro")
+
+# Ejemplo de guardar una respuesta dentro de un tema
+def guardar_respuesta(id_tema, data_respuesta):
+    """Guarda una respuesta en la subcolección 'respuestas' de un tema específico."""
+    respuestas_ref = foro_ref.document(id_tema).collection("respuestas")
+    respuestas_ref.add(data_respuesta)
 
 
 @app.errorhandler(GoogleAPICallError)

--- a/routes/client.py
+++ b/routes/client.py
@@ -57,7 +57,7 @@ def packs():
 def home():
     from firebase_admin import firestore
     from utils.drive_previews import fetch_previews
-    fs_client = firestore.client()
+    from app import fs_client
     try:
         docs = (
             fs_client.collection('foro')

--- a/scripts/check_firestore.py
+++ b/scripts/check_firestore.py
@@ -1,10 +1,17 @@
 import os, json, sys
-from firebase_admin import credentials, initialize_app, firestore
+import firebase_admin
+from firebase_admin import credentials, firestore
 
 # Carga credenciales
-path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "serviceAccountKey.json")
-cred = credentials.Certificate(path)
-initialize_app(cred)
+cred_json = os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+if not cred_json:
+    raise RuntimeError(
+        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
+
+cred = credentials.Certificate(json.loads(cred_json))
+if not firebase_admin._apps:
+    firebase_admin.initialize_app(cred)
 
 # Intenta leer las colecciones
 db = firestore.client()

--- a/scripts/firebase_init.py
+++ b/scripts/firebase_init.py
@@ -1,9 +1,17 @@
 import os
-from firebase_admin import credentials, initialize_app, firestore
+import json
+import firebase_admin
+from firebase_admin import credentials, firestore
 
-cred_path = os.getenv('GOOGLE_APPLICATION_CREDENTIALS', 'serviceAccountKey.json')
-if not os.path.isfile(cred_path):
-    raise RuntimeError(f"Archivo no encontrado: {cred_path}")
+firebase_creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+if not firebase_creds_json:
+    raise RuntimeError(
+        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
 
-initialize_app(credentials.Certificate(cred_path))
-print('✅ Firestore inicializado correctamente')
+cred_dict = json.loads(firebase_creds_json)
+cred = credentials.Certificate(cred_dict)
+if not firebase_admin._apps:
+    firebase_admin.initialize_app(cred)
+
+print("✅ Firestore inicializado correctamente")


### PR DESCRIPTION
## Summary
- init Firebase using GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable
- adapt client route to reuse global Firestore client
- update helper scripts and CI to use new variable
- document new setup in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6878ac338b188325865f83bf686e308d