### PR TITLE
Implement dual firebase initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ Los ecos del viaje transforman cada espacio en una oportunidad.
 El mañana se escribe con la tinta de nuestras colaboraciones.
 Cada encuentro aviva el fuego que ilumina nuestro sendero digital.
 Y cada paso suma nuevas melodías a nuestro legado colectivo.
+Las notas que dejamos guian a nuevos creadores en su travesia.

--- a/app.py
+++ b/app.py
@@ -3,8 +3,6 @@ import re
 import sqlite3
 import time
 import datetime
-import json
-import firebase_admin
 from google.cloud import firestore
 from werkzeug.security import generate_password_hash
 from flask import (
@@ -13,9 +11,9 @@ from flask import (
 )
 from jinja2 import TemplateNotFound
 
-from firebase_admin import credentials, firestore as fs, exceptions, initialize_app
 from google.api_core.exceptions import GoogleAPICallError
 from utils.template_filters import register_filters
+from utils.firebase import get_client as get_firestore_client
 
 
 
@@ -47,18 +45,8 @@ def create_app():
 
 app = create_app()
 
-# --- Firebase initialization for Render ---
-firebase_creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-if not firebase_creds_json:
-    raise Exception(
-        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
-    )
-cred_dict = json.loads(firebase_creds_json)
-cred = credentials.Certificate(cred_dict)
-if not firebase_admin._apps:
-    firebase_admin.initialize_app(cred)
-
-fs_client = firestore.client()
+# --- Firebase initialization (local/Render) ---
+fs_client = get_firestore_client()
 foro_ref = fs_client.collection("foro")
 
 # Ejemplo de guardar una respuesta dentro de un tema

--- a/scripts/check_firestore.py
+++ b/scripts/check_firestore.py
@@ -1,20 +1,7 @@
-import os, json, sys
-import firebase_admin
-from firebase_admin import credentials, firestore
+import sys
+from utils.firebase import get_client
 
-# Carga credenciales
-cred_json = os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-if not cred_json:
-    raise RuntimeError(
-        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
-    )
-
-cred = credentials.Certificate(json.loads(cred_json))
-if not firebase_admin._apps:
-    firebase_admin.initialize_app(cred)
-
-# Intenta leer las colecciones
-db = firestore.client()
+db = get_client()
 cols = db.collections()
 print("Colecciones en Firestore:")
 for c in cols:

--- a/scripts/firebase_init.py
+++ b/scripts/firebase_init.py
@@ -1,17 +1,4 @@
-import os
-import json
-import firebase_admin
-from firebase_admin import credentials, firestore
+from utils.firebase import get_client
 
-firebase_creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-if not firebase_creds_json:
-    raise RuntimeError(
-        "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
-    )
-
-cred_dict = json.loads(firebase_creds_json)
-cred = credentials.Certificate(cred_dict)
-if not firebase_admin._apps:
-    firebase_admin.initialize_app(cred)
-
+get_client()
 print("✅ Firestore inicializado correctamente")

--- a/utils/firebase.py
+++ b/utils/firebase.py
@@ -1,0 +1,21 @@
+import os
+import json
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+
+def get_client():
+    """Initialize Firebase using local file or env var and return Firestore client."""
+    if not firebase_admin._apps:
+        if os.environ.get("RENDER"):
+            cred_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+            if not cred_json:
+                raise RuntimeError(
+                    "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+                )
+            cred_dict = json.loads(cred_json)
+            cred = credentials.Certificate(cred_dict)
+        else:
+            cred = credentials.Certificate("serviceAccountKey.json")
+        firebase_admin.initialize_app(cred)
+    return firestore.client()


### PR DESCRIPTION
## Summary
- add utils to init firebase from env or local file
- integrate firebase utils into app and helper scripts
- extend README storyline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6878b04258188325bff0acfb049791b7