### PR TITLE
Fix Firestore init using env JSON

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ import re
 import sqlite3
 import time
 import datetime
+import json
+from google.oauth2 import service_account
 from google.cloud import firestore
 from werkzeug.security import generate_password_hash
 from flask import (
@@ -13,7 +15,6 @@ from jinja2 import TemplateNotFound
 
 from google.api_core.exceptions import GoogleAPICallError
 from utils.template_filters import register_filters
-from utils.firebase import get_client as get_firestore_client
 
 
 
@@ -46,8 +47,19 @@ def create_app():
 app = create_app()
 
 # --- Firebase initialization (local/Render) ---
-fs_client = get_firestore_client()
+credentials_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+
+if not credentials_json:
+    raise Exception("No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON")
+
+credentials_dict = json.loads(credentials_json)
+
+cred = service_account.Credentials.from_service_account_info(credentials_dict)
+
+fs_client = firestore.Client(credentials=cred)
+
 foro_ref = fs_client.collection("foro")
+respuestas_ref = fs_client.collection("respuestas")
 
 # Ejemplo de guardar una respuesta dentro de un tema
 def guardar_respuesta(id_tema, data_respuesta):

--- a/routes/client.py
+++ b/routes/client.py
@@ -55,7 +55,7 @@ def packs():
 
 @client_bp.route('/', methods=['GET'])
 def home():
-    from firebase_admin import firestore
+    from google.cloud import firestore
     from utils.drive_previews import fetch_previews
     from app import fs_client
     try:

--- a/utils/firebase.py
+++ b/utils/firebase.py
@@ -1,21 +1,26 @@
 import os
 import json
-import firebase_admin
-from firebase_admin import credentials, firestore
+from google.oauth2 import service_account
+from google.cloud import firestore
+
+
+_client = None
 
 
 def get_client():
-    """Initialize Firebase using local file or env var and return Firestore client."""
-    if not firebase_admin._apps:
-        if os.environ.get("RENDER"):
-            cred_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-            if not cred_json:
-                raise RuntimeError(
-                    "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
-                )
-            cred_dict = json.loads(cred_json)
-            cred = credentials.Certificate(cred_dict)
-        else:
-            cred = credentials.Certificate("serviceAccountKey.json")
-        firebase_admin.initialize_app(cred)
-    return firestore.client()
+    """Return a Firestore client initialized from env variable."""
+    global _client
+    if _client:
+        return _client
+
+    credentials_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+    if not credentials_json:
+        raise RuntimeError(
+            "No se encontró la variable de entorno GOOGLE_APPLICATION_CREDENTIALS_JSON"
+        )
+
+    credentials_dict = json.loads(credentials_json)
+    cred = service_account.Credentials.from_service_account_info(credentials_dict)
+
+    _client = firestore.Client(credentials=cred)
+    return _client


### PR DESCRIPTION
## Summary
- load Firestore credentials from `GOOGLE_APPLICATION_CREDENTIALS_JSON`
- update Firestore helper to use environment-based initialization
- switch client route to use `google.cloud.firestore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6878b3eca27c83258b972a2ba8d57a8a