### PR TITLE
Fix forum reply routing for string IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,4 @@ Y cada paso suma nuevas melodías a nuestro legado colectivo.
 Las notas que dejamos guian a nuevos creadores en su travesia.
 La innovación florece cuando compartimos nuestra pasión por aprender.
 Cada proyecto completado amplifica la voz de nuestra comunidad.
+Seguimos tejiendo redes que conectan a mentes curiosas alrededor del mundo.

--- a/app.py
+++ b/app.py
@@ -197,7 +197,7 @@ def get_all_comments():
 
 
 
-@app.route('/forum/<topic_id>')
+@app.route('/forum/<string:topic_id>')
 def view_topic(topic_id):
     try:
         doc = fs_client.collection('foro').document(topic_id).get()
@@ -218,7 +218,7 @@ def render_page(page):
         abort(404)
 # Agregar estas rutas al final de app.py, antes de if __name__ == '__main__':
 
-@app.route('/forum/topic/<topic_id>/responses')
+@app.route('/forum/topic/<string:topic_id>/responses')
 def get_topic_responses(topic_id):
     """Obtener respuestas de un tema específico"""
     try:
@@ -247,7 +247,7 @@ def get_topic_responses(topic_id):
         return jsonify([]), 500
 
 
-@app.route('/forum/topic/<topic_id>/delete', methods=['POST'])
+@app.route('/forum/topic/<string:topic_id>/delete', methods=['POST'])
 def delete_topic_route(topic_id):
     """Eliminar un tema del foro"""
     try:
@@ -295,7 +295,7 @@ if __name__ == '__main__':
     app.run(debug=app.config['DEBUG'])
 
 
-@app.route('/forum/topic/<topic_id>')
+@app.route('/forum/topic/<string:topic_id>')
 def forum_topic_view(topic_id):
     """Vista individual de un tema del foro"""
     try:
@@ -328,7 +328,7 @@ def forum_topic_view(topic_id):
         raise
 
 
-@app.route('/forum/topic/<topic_id>/reply', methods=['POST'])
+@app.route('/forum/topic/<string:topic_id>/reply', methods=['POST'])
 def forum_reply(topic_id):
     """Agregar respuesta a un tema"""
     try:

--- a/templates/forum_detail.html
+++ b/templates/forum_detail.html
@@ -14,7 +14,7 @@
   </div>
   <div class="topic-content">{{ topic.description or topic.contenido }}</div>
   {% if show_delete %}
-  <form action="{{ url_for('delete_topic', id=topic.id) }}" method="post">
+  <form action="{{ url_for('delete_topic_route', topic_id=topic.id) }}" method="post">
     <input type="hidden" name="password" value="borrar1">
     <button type="submit" class="btn-delete">🗑 Eliminar</button>
   </form>

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -20,7 +20,7 @@
     {% else %}
     <p class="no-resp">No hay respuestas aún. Sé el primero en responder:</p>
     {% endfor %}
-    <form action="{{ url_for('forum_topic_view', topic_id=topic.id) }}" method="post">
+    <form action="{{ url_for('forum_reply', topic_id=topic.id) }}" method="post">
       <div class="form-group">
         <label for="author">Tu nombre</label>
         <input id="author" name="author" type="text" required class="input-author" placeholder="Tu nombre…">


### PR DESCRIPTION
## Summary
- use `<string:topic_id>` in all forum routes
- post replies to `/forum/topic/<id>/reply`
- fix delete form endpoint name
- extend community story in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687943dad0588325ac9820fa2e0657a5