### PR TITLE
Fix forum form field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,4 @@ La innovación florece cuando compartimos nuestra pasión por aprender.
 Cada proyecto completado amplifica la voz de nuestra comunidad.
 Seguimos tejiendo redes que conectan a mentes curiosas alrededor del mundo.
 Cada proyecto exitoso nutre el terreno donde germinarán las ideas del mañana.
+La constancia de nuestro esfuerzo modela paisajes de creatividad sin límites.

--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ from utils.forum_utils import (
     mapeo_datos,
     normalize_response_data,
     get_content_from_form,
+    get_form_field,
 )
 
 def create_app():
@@ -272,10 +273,12 @@ def delete_topic_route(topic_id):
 @app.route('/forum/new', methods=['GET', 'POST'], endpoint='create_new_forum')
 def forum_new():
     if request.method == 'POST':
-        nombre = request.form.get('author') or request.form.get('nombre', 'Anónimo')
-        categoria = request.form.get('category') or request.form.get('categoria', '')
-        titulo = request.form.get('title') or request.form.get('titulo', '')
-        contenido = request.form.get('description') or request.form.get('contenido', '')
+        print("Form data received:", request.form.to_dict())
+
+        nombre = get_form_field(request, ['autor', 'author', 'nombre']) or 'Anónimo'
+        categoria = get_form_field(request, ['categoria', 'category']) or ''
+        titulo = get_form_field(request, ['titulo', 'title'])
+        contenido = get_form_field(request, ['contenido', 'description', 'content'])
 
         if not titulo or not contenido:
             return "Título y contenido son obligatorios", 400

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -75,12 +75,12 @@
         <div class="new-topic-form" id="newTopicForm">
             <form id="topicForm" action="{{ url_for('create_new_forum') }}" method="post">
                 <div class="form-group">
-                    <label class="form-label" for="authorName">Nombre:</label>
-                    <input type="text" id="authorName" name="author" class="form-input" placeholder="Tu nombre" required>
+                    <label class="form-label" for="autor">Nombre:</label>
+                    <input type="text" id="autor" name="autor" class="form-input" placeholder="Tu nombre" required>
                 </div>
                 <div class="form-group">
-                    <label class="form-label" for="category">Categoría:</label>
-                    <select id="category" name="category" class="form-select" required>
+                    <label class="form-label" for="categoria">Categoría:</label>
+                    <select id="categoria" name="categoria" class="form-select" required>
                         <option value="">Selecciona una categoría</option>
                         {% for cat in categories %}
                         <option value="{{ cat }}">{{ cat }}</option>
@@ -88,12 +88,12 @@
                     </select>
                 </div>
                 <div class="form-group">
-                    <label class="form-label" for="title">Título:</label>
-                    <input type="text" id="title" name="title" class="form-input" placeholder="Un título descriptivo para tu tema" required>
+                    <label class="form-label" for="titulo">Título:</label>
+                    <input type="text" id="titulo" name="titulo" class="form-input" placeholder="Un título descriptivo para tu tema" required>
                 </div>
                 <div class="form-group">
-                    <label class="form-label" for="content">Contenido:</label>
-                    <textarea id="content" name="content" class="form-textarea" placeholder="Describe tu problema, pregunta o comparte tu conocimiento..." required></textarea>
+                    <label class="form-label" for="contenido">Contenido:</label>
+                    <textarea id="contenido" name="contenido" class="form-textarea" placeholder="Describe tu problema, pregunta o comparte tu conocimiento..." required></textarea>
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn-secondary" id="cancelBtn">Cancelar</button>

--- a/templates/forum_new.html
+++ b/templates/forum_new.html
@@ -7,18 +7,18 @@
   <h1 class="section-title">CREAR NUEVO TEMA</h1>
   <p class="section-desc">Comparte tu reto audiovisual y colabora con la comunidad VFORUM.</p>
   <form action="{{ url_for('create_new_forum') }}" method="post" enctype="multipart/form-data">
-    <label for="title">Título</label>
-    <input id="title" name="title" type="text" required>
+    <label for="titulo">Título</label>
+    <input id="titulo" name="titulo" type="text" required>
 
-    <label for="category">Categoría</label>
-    <select id="category" name="category" required>
+    <label for="categoria">Categoría</label>
+    <select id="categoria" name="categoria" required>
       {% for cat in categories %}
         <option value="{{ cat }}">{{ cat }}</option>
       {% endfor %}
     </select>
 
-    <label for="description">Descripción</label>
-    <textarea id="description" name="description" required></textarea>
+    <label for="contenido">Descripción</label>
+    <textarea id="contenido" name="contenido" required></textarea>
 
     <label for="file">Adjuntar imagen (opcional)</label>
     <input id="file" name="file" type="file" accept="image/*">

--- a/utils/forum_utils.py
+++ b/utils/forum_utils.py
@@ -48,3 +48,12 @@ def get_content_from_form(payload):
         or payload.get('response')
         or ''
     )
+
+
+def get_form_field(req, field_names):
+    """Busca un campo en ``request.form`` usando múltiples nombres."""
+    for name in field_names:
+        value = req.form.get(name)
+        if value and value.strip():
+            return value.strip()
+    return None


### PR DESCRIPTION
## Summary
- rename forum form fields to Spanish identifiers
- handle alternate names in the backend
- add helper to read multiple possible form names
- extend narrative in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6879600ac4888325b7246e05b005b85f