### PR TITLE
Add unified authentication blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,4 @@ Cada proyecto completado amplifica la voz de nuestra comunidad.
 Seguimos tejiendo redes que conectan a mentes curiosas alrededor del mundo.
 Cada proyecto exitoso nutre el terreno donde germinarán las ideas del mañana.
 La constancia de nuestro esfuerzo modela paisajes de creatividad sin límites.
+Cada sendero construido inspira nuevas aventuras digitales.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -37,6 +37,8 @@ CREATE TABLE IF NOT EXISTS users (
     email TEXT UNIQUE,
     password TEXT,
     is_admin INTEGER DEFAULT 0,
+    username TEXT,
+    role TEXT DEFAULT 'user',
     verified INTEGER DEFAULT 0,
     verification_code TEXT,
     profile_pic TEXT,

--- a/models/user.py
+++ b/models/user.py
@@ -7,6 +7,8 @@ class User(db.Model, TimestampMixin):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(128))
     is_admin = db.Column(db.Boolean, default=False)
+    username = db.Column(db.String(64))
+    role = db.Column(db.String(32), default='user')
     verified = db.Column(db.Boolean, default=False)
     verification_code = db.Column(db.String(120))
     profile_pic = db.Column(db.String(256))

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+from werkzeug.security import generate_password_hash
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        email = request.form['email']
+        password = request.form['password']
+        from app import get_user, check_password
+        user = get_user(email)
+        if user and check_password(email, password):
+            session['user'] = email
+            session['role'] = user.get('role', 'user')
+            if user['role'] == 'admin':
+                session['admin'] = email
+                return redirect(url_for('admin.admin'))
+            if user['role'] == 'client':
+                return redirect(url_for('client.dashboard'))
+            return redirect(url_for('list_forum'))
+        flash('Credenciales inválidas', 'error')
+    return render_template('login.html')
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        email = request.form['email']
+        username = request.form['username']
+        password = request.form['password']
+        from app import create_user
+        create_user(email, password, username=username, role='user')
+        flash('Usuario creado. Revisa tu email para verificar', 'success')
+        return redirect(url_for('auth.login'))
+    return render_template('register.html')

--- a/routes/client.py
+++ b/routes/client.py
@@ -178,7 +178,12 @@ def upload_profile():
 @client_bp.route('/dashboard/logout', methods=['POST'])
 @login_required
 def logout():
-    session.pop('user', None)
+    user_email = session.pop('user', None)
+    if user_email:
+        from app import get_user, remove_online
+        user = get_user(user_email)
+        if user:
+            remove_online(user['id'])
     return redirect(url_for('client.dashboard'))
 
 

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -194,22 +194,18 @@
                 Staff Online
             </div>
             <div class="user-list">
+                {% for u in online_staff %}
                 <div class="user-item">
                     <div class="user-avatar"></div>
                     <div class="user-info">
-                        <div class="user-name">Diego Bastías</div>
-                        <div class="user-role">Admin Developer</div>
+                        <div class="user-name">{{ u.id }}</div>
+                        <div class="user-role">{{ u.role }}</div>
                     </div>
                     <div class="online-indicator"></div>
                 </div>
-                <div class="user-item">
-                    <div class="user-avatar"></div>
-                    <div class="user-info">
-                        <div class="user-name">Ana García</div>
-                        <div class="user-role">Moderadora</div>
-                    </div>
-                    <div class="online-indicator"></div>
-                </div>
+                {% else %}
+                <div class="user-item">No staff online</div>
+                {% endfor %}
             </div>
         </div>
         <div class="widget">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<div class="dashboard-container">
+  <div class="dashboard-login">
+    <h2>Ingresar</h2>
+    <form method="POST">
+      <input type="email" name="email" placeholder="Email" required>
+      <input type="password" name="password" placeholder="Contraseña" required>
+      <button type="submit">Entrar</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}Registro{% endblock %}
+{% block content %}
+<div class="dashboard-container">
+  <div class="dashboard-login">
+    <h2>Crear cuenta</h2>
+    <form method="POST">
+      <input type="email" name="email" placeholder="Email" required>
+      <input type="text" name="username" placeholder="Nombre de usuario" required>
+      <input type="password" name="password" placeholder="Contraseña" required>
+      <button type="submit">Registrar</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -20,8 +20,8 @@ def ensure_admin_user():
     # Default admin password should be fixed for simplicity
     password = "admin2025"
     conn.execute(
-        "INSERT INTO users (email, password, is_admin, verified) VALUES (?, ?, 1, 1)",
-        ("admin@verite.cl", password),
+        "INSERT INTO users (email, password, is_admin, username, role, verified) VALUES (?, ?, 1, ?, 'admin', 1)",
+        ("admin@verite.cl", password, "admin"),
     )
     conn.commit()
     admin = conn.execute(

--- a/utils/db.py
+++ b/utils/db.py
@@ -104,6 +104,14 @@ def init_db(app):
 
     ensure_projects_schema(cursor)
 
+    # Ensure new columns exist in users table
+    cursor.execute("PRAGMA table_info(users)")
+    existing = [row[1] for row in cursor.fetchall()]
+    if 'username' not in existing:
+        cursor.execute("ALTER TABLE users ADD COLUMN username TEXT")
+    if 'role' not in existing:
+        cursor.execute("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'user'")
+
     cursor.execute(
         """
         CREATE TABLE IF NOT EXISTS comments (


### PR DESCRIPTION
## Summary
- extend users table with `username` and `role`
- ensure columns exist in DB initialization
- implement unified auth blueprint with `/login` and `/register`
- track online staff in memory and expose through context
- show online staff dynamically in forum sidebar
- update logout to remove online status
- add missing columns to ORM model
- add README line

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68799154935883259a575536def9372f