### PR TITLE
Fix datetime timezone awareness

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import re
 import sqlite3
 import time
 import datetime
-from datetime import datetime as dt, timezone
+from datetime import datetime as dt, timezone, timedelta
 import json
 try:
     from google.oauth2 import service_account
@@ -48,11 +48,11 @@ def mark_online(user_id, role):
     ONLINE_USERS[user_id] = {
         'id': user_id,
         'role': role,
-        'last': dt.utcnow()
+        'last': dt.now(timezone.utc)
     }
 
 def prune_online():
-    now = dt.utcnow()
+    now = dt.now(timezone.utc)
     for uid, info in list(ONLINE_USERS.items()):
         if (now - info['last']).total_seconds() > 300:
             ONLINE_USERS.pop(uid, None)
@@ -75,7 +75,7 @@ def get_online_staff():
     if not usuarios_ref:
         return []
 
-    five_minutes_ago = datetime.utcnow() - timedelta(minutes=5)
+    five_minutes_ago = datetime.datetime.now(datetime.timezone.utc) - timedelta(minutes=5)
     online_staff = []
     staff_query = usuarios_ref.where('role', 'in', ['admin', 'moderator']).where('is_online', '==', True).stream()
 
@@ -366,7 +366,7 @@ def forum_new():
             'category': categoria,
             'title': titulo,
             'description': contenido,
-            'created_at': datetime.datetime.utcnow().isoformat()
+            'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat()
         }
 
         fs_client.collection('foro').add(nuevo_tema)
@@ -461,7 +461,7 @@ def responder(post_id):
 
         respuesta_data = {
             'content': contenido,
-            'created_at': datetime.datetime.utcnow(),
+            'created_at': datetime.datetime.now(datetime.timezone.utc),
             'author': 'Anónimo'
         }
 
@@ -535,7 +535,7 @@ def forum_context():
 
     online_count = 0
     if usuarios_ref:
-        five_minutes_ago = datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
+        five_minutes_ago = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
         online_users = usuarios_ref.where('is_online', '==', True).stream()
         for doc in online_users:
             user = doc.to_dict()

--- a/modules/forum.py
+++ b/modules/forum.py
@@ -1,6 +1,6 @@
 import sqlite3
 import re
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Tuple
 from flask import current_app
 
@@ -58,7 +58,7 @@ def _parse_datetime(value):
         try:
             return datetime.fromisoformat(value)
         except Exception:
-            return datetime.utcnow()
+            return datetime.now(timezone.utc)
     return value
 
 # Categorías fijas para el foro
@@ -252,12 +252,12 @@ def get_all_topics() -> Tuple[List[Dict], bool]:
             'title': 'Título demo',
             'body': 'Este es un contenido de demostración. ¡Crea tu primer tema!',
             'category': None,
-            'created_at': datetime.utcnow(),
+            'created_at': datetime.now(timezone.utc),
             'likes': 0,
             'responses': [{
                 'author': 'Demo',
                 'body': 'Respuesta demo',
-                'created_at': datetime.utcnow()
+                'created_at': datetime.now(timezone.utc)
             }]
         }]
         demo_mode = True
@@ -326,7 +326,7 @@ def create_response(topic_id: int, author: str, content: str) -> int:
     try:
         cur.execute(
             'INSERT INTO responses (topic_id, author, content, created_at) VALUES (?,?,?,?)',
-            (topic_id, author, content, datetime.utcnow())
+            (topic_id, author, content, datetime.now(timezone.utc))
         )
         conn.commit()
         return cur.lastrowid
@@ -344,7 +344,7 @@ def vote_response(response_id: int, delta: int) -> None:
     try:
         cur.execute(
             'INSERT INTO votes (response_id, delta, created_at) VALUES (?,?,?)',
-            (response_id, delta, datetime.utcnow())
+            (response_id, delta, datetime.now(timezone.utc))
         )
         conn.commit()
     except Exception as e:
@@ -381,7 +381,7 @@ def create_topic(form, files) -> int:
     cur = conn.cursor()
     cur.execute(
         'INSERT INTO topics (title, slug, category, description, image, created_at) VALUES (?,?,?,?,?,?)',
-        (title, slug, category, description, image, datetime.utcnow())
+        (title, slug, category, description, image, datetime.now(timezone.utc))
     )
     conn.commit()
     topic_id = cur.lastrowid
@@ -392,7 +392,7 @@ def create_post(topic_id: int, author: str, content: str) -> int:
     conn = _connect()
     cur = conn.cursor()
     cur.execute('INSERT INTO posts (topic_id, author, content, created_at) VALUES (?,?,?,?)',
-                (topic_id, author, content, datetime.utcnow()))
+                (topic_id, author, content, datetime.now(timezone.utc)))
     conn.commit()
     post_id = cur.lastrowid
     conn.close()


### PR DESCRIPTION
## Summary
- fix usage of `datetime.utcnow()` across modules
- ensure timezone-aware timestamps with `datetime.now(timezone.utc)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6879a1922db0832594242c9d0e5b9099