### PR TITLE
Add truncate words filter and remove placeholder binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ __pycache__/
 *.sqlite3
 *.log
 logs/
-static/previews/default_preview.mp3
 serviceAccountKey.json

--- a/README.md
+++ b/README.md
@@ -202,3 +202,4 @@ La constancia de nuestro esfuerzo modela paisajes de creatividad sin límites.
 Cada sendero construido inspira nuevas aventuras digitales.
 El eco compartido de nuestras hazañas invita a explorar más allá del horizonte.
 
+Nuestros logros se entrelazan con la energia de quienes se suman a esta aventura.

--- a/static/css/home_brutalista.css
+++ b/static/css/home_brutalista.css
@@ -88,7 +88,7 @@ body {
   right: 0;
   bottom: 0;
   left: 0;
-  background: url('/static/img/bg-pattern.png') center/cover no-repeat;
+  /* background: url('/static/img/bg-pattern.png') center/cover no-repeat; */
   opacity: .05;
 }
 .stats-container {

--- a/utils/template_filters.py
+++ b/utils/template_filters.py
@@ -31,6 +31,18 @@ def timestamp_local(timestamp):
     return format_timestamp_local(timestamp)
 
 
+def truncate_words(text, num_words):
+    """Return the text truncated to ``num_words`` words with ellipsis."""
+    if not text:
+        return ""
+
+    words = str(text).split()
+    if len(words) <= num_words:
+        return str(text)
+    return " ".join(words[:num_words]) + "..."
+
+
 def register_filters(app):
     """Register template filters with the Flask app"""
     app.jinja_env.filters["timestamp_local"] = timestamp_local
+    app.jinja_env.filters["truncate_words"] = truncate_words


### PR DESCRIPTION
## Summary
- add a template filter to truncate text after a given word count
- register template filters within `app.py`
- remove binary placeholder assets and keep empty files for compatibility
- update the CSS background reference to avoid missing image
- extend the README story

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6879c4f2d47c83259f0089c340575c20