### PR TITLE
Refactor Firestore client

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,10 +6,8 @@ from datetime import datetime as dt, timezone, timedelta
 import json
 
 try:
-    from google.oauth2 import service_account
     from google.cloud import firestore
 except Exception:  # pragma: no cover - optional deps for tests
-    service_account = None
     firestore = None
 
 from werkzeug.security import generate_password_hash
@@ -35,6 +33,7 @@ from routes.projects import projects_bp
 from routes.messages import messages_bp
 from services.project_manager import ProjectManager
 from services.comment_manager import CommentManager
+from services.fs_client import fs_client
 from utils.quotes import get_random_quote
 from modules.forum import get_categories
 from utils.forum_utils import (
@@ -66,17 +65,14 @@ app.register_blueprint(projects_bp)
 app.register_blueprint(messages_bp)
 
 # Inicializar Firebase/Firestore si está disponible
-fs_client = None
 usuarios_ref = None
 foro_ref = None
 
 try:
-    if service_account and firestore:
-        from utils.firebase import get_client
-        fs_client = get_client()
+    if fs_client:
         usuarios_ref = fs_client.collection('usuarios')
         foro_ref = fs_client.collection('foro')
-except Exception as e:
+except Exception as e:  # pragma: no cover - runtime env may lack Firestore
     print(f"Warning: Firebase no disponible: {e}")
 
 # Funciones helper para usuarios online

--- a/routes/client.py
+++ b/routes/client.py
@@ -58,7 +58,7 @@ def home():
     from google.cloud import firestore
     from utils.drive_previews import fetch_previews
     from utils.forum_utils import mapeo_datos
-    from app import fs_client
+    from services.fs_client import fs_client
     try:
         docs = (
             fs_client.collection('foro')

--- a/routes/messages.py
+++ b/routes/messages.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, session
 from google.cloud import firestore
-from app import fs_client
+from services.fs_client import fs_client
 
 messages_bp = Blueprint('messages', __name__)
 

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify, session
 from google.cloud import firestore
 from datetime import datetime, timezone
-from app import fs_client
+from services.fs_client import fs_client
 
 projects_bp = Blueprint('projects', __name__)
 

--- a/services/fs_client.py
+++ b/services/fs_client.py
@@ -1,0 +1,15 @@
+try:
+    from google.oauth2 import service_account
+    from google.cloud import firestore
+except Exception:  # pragma: no cover - optional deps for tests
+    service_account = None
+    firestore = None
+
+fs_client = None
+
+try:
+    if service_account and firestore:
+        from utils.firebase import get_client
+        fs_client = get_client()
+except Exception as e:  # pragma: no cover - runtime env may lack creds
+    print(f"Warning: Firebase no disponible: {e}")


### PR DESCRIPTION
## Summary
- factor Firestore initialization into new `services.fs_client`
- update imports to use new module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6879cf0709b4832584b2385568aee440