### PR TITLE
Unify design system palette

### DIFF
--- a/static/css/forum_interactive.css
+++ b/static/css/forum_interactive.css
@@ -27,7 +27,7 @@
 
 /* Override base styles for forum */
 .forum-container {
-    font-family: 'Montserrat', 'Roboto', sans-serif !important;
+    font-family: 'Poppins', 'Roboto', sans-serif !important;
     background: var(--bg-primary) !important;
     color: var(--text-primary) !important;
     line-height: 1.6;

--- a/static/css/home_brutalista.css
+++ b/static/css/home_brutalista.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&family=Montserrat:wght@700;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&family=Poppins:wght@700;900&display=swap');
 :root {
   --primary: #00D4B8;
   --accent: #FF6B35;
@@ -28,7 +28,7 @@ body {
   overflow: hidden;
 }
 .hero-title {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-weight: 900;
   font-size: clamp(2.5rem,6vw,5rem);
   margin-bottom: 1rem;
@@ -122,7 +122,7 @@ body {
   font-size: 2rem;
 }
 .feature-title {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-weight: 700;
   margin-top: 0.5rem;
 }
@@ -197,7 +197,7 @@ body {
   margin-bottom: 1rem;
 }
 .cta-title {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-weight: 900;
   font-size: clamp(2rem,5vw,3.5rem);
 }

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -7,9 +7,10 @@ header.app-bar{
   z-index:1000;
 }
 .app-bar .logo{
-  font-family:'Inter',sans-serif;font-weight:800;letter-spacing:.04em;
-  font-size:clamp(1.8rem,3vw,4rem);line-height:1;color:#fff;text-decoration:none;
+  font-family:'Poppins',sans-serif;font-weight:800;letter-spacing:.04em;
+  font-size:clamp(1.8rem,3vw,4rem);line-height:60px;color:#fff;text-decoration:none;
   background:none !important;transition:font-size .3s;
+  display:block;min-width:180px;min-height:60px;
 }
 .app-bar .logo:hover{background:none;font-size:clamp(2rem,3.4vw,4.4rem);}
 .forum-link{
@@ -71,3 +72,10 @@ header.app-bar{
   transition:opacity 1.8s ease;
 }
 #quoteRotator.hide{opacity:0;}
+
+@media (max-width: 600px) {
+  .app-bar .logo {
+    min-width: 180px;
+    min-height: 60px;
+  }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,25 +1,71 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;900&family=Montserrat:wght@400;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700;900&display=swap');
 @import url("https://fonts.googleapis.com/css2?family=Fira+Code&display=swap");
 
 :root {
-  --accent-color: #00D4B8;
+  --primary-color: #1a5f7a;
+  --secondary-color: #2c88aa;
+  --accent-color: #f8b195;
+  --accent-alt: #355c7d;
+  --background-light: #f5f7f9;
+  --background-white: #ffffff;
+  --text-primary: #2d3748;
+  --text-secondary: #4a5568;
+  --border-color: #e2e8f0;
+  --border-radius: 8px;
+  --transition-speed: 0.3s;
+  --box-shadow: 0 1px 3px rgba(0,0,0,0.12);
   --gradient-silver: linear-gradient(45deg, #ccc, #eee);
   --border-silver: #2A3441;
   --bg-dark: #0A0F1C;
   --text-light: #E9E9E9;
+  /* Legacy variable aliases */
+  --primary: var(--primary-color);
+  --secondary: var(--secondary-color);
+  --accent: var(--accent-color);
+  --bg-1: var(--background-light);
 }
 
 body {
   font-family: 'Inter', sans-serif;
-  background-color: var(--bg-dark);
-  color: var(--text-light);
+  background-color: var(--background-light);
+  color: var(--text-primary);
   margin: 0;
   padding-top: 120px;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
+}
+
+/* Utility classes */
+.btn {
+  background: var(--primary-color);
+  color: var(--background-white);
+  border-radius: var(--border-radius);
+  padding: 12px 24px;
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition-speed);
+  text-decoration: none;
+  display: inline-block;
+}
+.btn:hover {
+  background: #154a60;
+}
+
+.card {
+  background: var(--background-white);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  padding: 1rem;
+}
+
+.input {
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  height: 42px;
+  padding: 0 0.75rem;
 }
 
 .header {
@@ -37,7 +83,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .logo {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-weight: 900;
   font-size: 3.5rem;
   max-width: 100%;
@@ -353,7 +399,7 @@ a:hover, button:hover {
   position: relative;
 }
 .hero-container h1 {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-weight: 900;
   font-size: clamp(4rem, 8vw, 6rem);
   margin: 0;
@@ -367,7 +413,7 @@ a:hover, button:hover {
 }
 
 .section-title {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-weight: 900;
   font-size: clamp(2.5rem,5vw,5rem);
   text-align: center;
@@ -640,7 +686,7 @@ body.forum-new {
 }
 
 .vforum-title {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-size: 4rem;
   font-weight: 900;
   text-align: center;
@@ -743,7 +789,7 @@ body.forum-new {
   color: #000;
 }
 .topic-title {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Poppins', sans-serif;
   font-size: 2.5rem;
   margin-bottom: 0.5rem;
 }
@@ -854,7 +900,7 @@ body.forum-new {
   border-radius: 8px;
   padding: 0.75rem 1rem;
   color: #fff;
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 1rem;
   transition: border-color 0.3s ease;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>{% block title %}Verité{% endblock %}</title>
   <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@900&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700;900&display=swap" rel="stylesheet">
   <!-- Fuente principal para la sección de administración -->
   <link href="https://fonts.googleapis.com/css2?family=Verite+Sans:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,7 +2,7 @@
 {% block title %}VERITÉ - Contenido Audiovisual Real{% endblock %}
 
 {% block extra_head %}
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&family=Montserrat:wght@700;900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&family=Poppins:wght@700;900&display=swap" rel="stylesheet">
 {% endblock %}
 
 {% block content %}

--- a/templates/vforum_auth.html
+++ b/templates/vforum_auth.html
@@ -44,7 +44,7 @@
 }
 
 .auth-title {
-    font-family: 'Montserrat', sans-serif;
+    font-family: 'Poppins', sans-serif;
     font-size: 3.5rem;
     font-weight: 900;
     background: linear-gradient(135deg, var(--auth-primary), var(--auth-accent));


### PR DESCRIPTION
## Summary
- update fonts to Inter & Poppins
- apply unified color palette and utility classes
- ensure header logo keeps minimum size and is responsive

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - Werkzeug not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879e686bda483258592e37355fa1b17