### PR TITLE
Implement solicitudes panel and user status

### DIFF
--- a/routes/friends.py
+++ b/routes/friends.py
@@ -1,18 +1,95 @@
 from flask import Blueprint, request, jsonify, session
+from datetime import datetime
+from services.fs_client import fs_client
 
 friends_bp = Blueprint('friends', __name__)
 
 @friends_bp.route('/send_friend_request', methods=['POST'])
 def send_friend_request():
     """Enviar solicitud de amistad."""
-    return jsonify({'message': 'Not implemented'}), 501
+    try:
+        if 'user_id' not in session:
+            return jsonify({'success': False, 'error': 'No autenticado'}), 401
+        data = request.get_json()
+        receptor_id = data.get('receptor_id')
+        if not receptor_id:
+            return jsonify({'success': False, 'error': 'Datos incompletos'}), 400
+        solicitante_id = session['user_id']
+        solicitud = {
+            'solicitante_id': solicitante_id,
+            'receptor_id': receptor_id,
+            'solicitante_nombre': session.get('user_name', 'Usuario'),
+            'estado': 'pendiente',
+            'fecha_solicitud': datetime.now()
+        }
+        fs_client.collection('amistades').add(solicitud)
+        return jsonify({'success': True})
+    except Exception as e:
+        print(f"Error sending friend request: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 @friends_bp.route('/respond_friend_request', methods=['POST'])
 def respond_friend_request():
     """Aceptar o rechazar una solicitud."""
-    return jsonify({'message': 'Not implemented'}), 501
+    try:
+        if 'user_id' not in session:
+            return jsonify({'success': False, 'error': 'No autenticado'}), 401
+        data = request.get_json()
+        solicitud_id = data.get('solicitud_id')
+        accion = data.get('accion')
+        if not solicitud_id or not accion:
+            return jsonify({'success': False, 'error': 'Datos incompletos'}), 400
+        solicitud_ref = fs_client.collection('amistades').document(solicitud_id)
+        solicitud_doc = solicitud_ref.get()
+        if not solicitud_doc.exists:
+            return jsonify({'success': False, 'error': 'Solicitud no encontrada'}), 404
+        solicitud_data = solicitud_doc.to_dict()
+        if solicitud_data['receptor_id'] != session['user_id']:
+            return jsonify({'success': False, 'error': 'No autorizado'}), 403
+        nuevo_estado = 'aceptada' if accion == 'aceptar' else 'rechazada'
+        solicitud_ref.update({
+            'estado': nuevo_estado,
+            'fecha_respuesta': datetime.now()
+        })
+        return jsonify({'success': True})
+    except Exception as e:
+        print(f"Error responding friend request: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+@friends_bp.route('/get_friend_requests', methods=['GET'])
+def get_friend_requests():
+    """Obtener solicitudes de amistad pendientes"""
+    try:
+        if 'user_id' not in session:
+            return jsonify({'success': False, 'error': 'No autenticado'}), 401
+        user_id = session['user_id']
+        solicitudes_query = fs_client.collection('amistades')\
+                             .where('receptor_id', '==', user_id)\
+                             .where('estado', '==', 'pendiente')
+        solicitudes = []
+        for doc in solicitudes_query.stream():
+            solicitud_data = doc.to_dict()
+            solicitud_data['id'] = doc.id
+            solicitudes.append(solicitud_data)
+        return jsonify({'success': True, 'solicitudes': solicitudes})
+    except Exception as e:
+        print(f"Error getting friend requests: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 @friends_bp.route('/get_friends', methods=['GET'])
 def get_friends():
     """Obtener lista de amigos del usuario actual."""
-    return jsonify({'friends': []})
+    try:
+        if 'user_id' not in session:
+            return jsonify({'friends': []})
+        user_id = session['user_id']
+        amistades = fs_client.collection('amistades')\
+                     .where('estado', '==', 'aceptada')\
+                     .where('receptor_id', '==', user_id).stream()
+        friends = []
+        for doc in amistades:
+            info = doc.to_dict()
+            friends.append(info)
+        return jsonify({'friends': friends})
+    except Exception:
+        return jsonify({'friends': []})

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -150,3 +150,92 @@ def accept_member(project_id, user_id):
         print(f"Error accepting member: {e}")
         return jsonify({'error': str(e)}), 500
 
+
+@projects_bp.route('/get_project_requests', methods=['GET'])
+def get_project_requests():
+    """Obtener solicitudes de proyectos del usuario actual"""
+    try:
+        if 'user_id' not in session:
+            return jsonify({'success': False, 'error': 'No autenticado'}), 401
+        
+        user_id = session['user_id']
+        proyectos_query = fs_client.collection('proyectos').where('autor_id', '==', user_id)
+        proyectos = proyectos_query.stream()
+
+        solicitudes = []
+        for proyecto in proyectos:
+            proyecto_data = proyecto.to_dict()
+            proyecto_id = proyecto.id
+            solicitudes_query = fs_client.collection('solicitudes_proyecto')\
+                                 .where('proyecto_id', '==', proyecto_id)\
+                                 .where('estado', '==', 'pendiente')
+            for solicitud in solicitudes_query.stream():
+                solicitud_data = solicitud.to_dict()
+                solicitud_data['id'] = solicitud.id
+                solicitud_data['proyecto_titulo'] = proyecto_data.get('titulo', 'Proyecto sin título')
+                solicitudes.append(solicitud_data)
+        return jsonify({'success': True, 'solicitudes': solicitudes})
+    except Exception as e:
+        print(f"Error getting project requests: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+@projects_bp.route('/respond_project_request', methods=['POST'])
+def respond_project_request():
+    """Responder a solicitud de proyecto"""
+    try:
+        if 'user_id' not in session:
+            return jsonify({'success': False, 'error': 'No autenticado'}), 401
+        
+        data = request.get_json()
+        solicitud_id = data.get('solicitud_id')
+        accion = data.get('accion')
+        
+        if not solicitud_id or not accion:
+            return jsonify({'success': False, 'error': 'Datos incompletos'}), 400
+        
+        solicitud_ref = fs_client.collection('solicitudes_proyecto').document(solicitud_id)
+        solicitud_doc = solicitud_ref.get()
+        if not solicitud_doc.exists:
+            return jsonify({'success': False, 'error': 'Solicitud no encontrada'}), 404
+        solicitud_data = solicitud_doc.to_dict()
+
+        proyecto_ref = fs_client.collection('proyectos').document(solicitud_data['proyecto_id'])
+        proyecto_doc = proyecto_ref.get()
+        if not proyecto_doc.exists:
+            return jsonify({'success': False, 'error': 'Proyecto no encontrado'}), 404
+        proyecto_data = proyecto_doc.to_dict()
+        if proyecto_data['autor_id'] != session['user_id']:
+            return jsonify({'success': False, 'error': 'No autorizado'}), 403
+
+        nuevo_estado = 'aceptada' if accion == 'aceptar' else 'rechazada'
+        solicitud_ref.update({
+            'estado': nuevo_estado,
+            'fecha_respuesta': datetime.now()
+        })
+
+        if accion == 'aceptar':
+            profesion = solicitud_data['profesion_solicitada']
+            profesiones = proyecto_data.get('profesiones_requeridas', {})
+            if profesion in profesiones:
+                profesiones[profesion]['ocupados'] += 1
+                if profesiones[profesion]['ocupados'] >= profesiones[profesion]['cupos']:
+                    profesiones[profesion]['activo'] = False
+            miembro = {
+                'user_id': solicitud_data['solicitante_id'],
+                'nombre': solicitud_data['solicitante_nombre'],
+                'profesion': profesion,
+                'fecha_union': datetime.now()
+            }
+            miembros_aceptados = proyecto_data.get('miembros_aceptados', [])
+            miembros_aceptados.append(miembro)
+            todas_completas = all(not prof['activo'] for prof in profesiones.values())
+            nuevo_estado_proyecto = 'en_desarrollo' if todas_completas else 'abierto'
+            proyecto_ref.update({
+                'profesiones_requeridas': profesiones,
+                'miembros_aceptados': miembros_aceptados,
+                'estado_proyecto': nuevo_estado_proyecto
+            })
+        return jsonify({'success': True, 'message': f'Solicitud {nuevo_estado} correctamente'})
+    except Exception as e:
+        print(f"Error responding to project request: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/routes/user_status.py
+++ b/routes/user_status.py
@@ -1,13 +1,70 @@
 from flask import Blueprint, request, jsonify, session
+from datetime import datetime, timedelta
+from services.fs_client import fs_client
 
 status_bp = Blueprint('status', __name__)
 
 @status_bp.route('/update_status', methods=['POST'])
 def update_status():
-    """Actualizar el estado de conexión del usuario."""
-    return jsonify({'message': 'Not implemented'}), 501
+    """Actualizar estado de conexión del usuario"""
+    try:
+        if 'user_id' not in session:
+            return jsonify({'success': False, 'error': 'No autenticado'}), 401
+        data = request.get_json()
+        new_status = data.get('status', 'online')
+        if new_status not in ['online', 'ocupado', 'offline']:
+            return jsonify({'success': False, 'error': 'Estado inválido'}), 400
+        user_id = session['user_id']
+        estado_data = {
+            'user_id': user_id,
+            'estado': new_status,
+            'ultima_actividad': datetime.now(),
+            'en_chat': False,
+            'proyecto_activo': None
+        }
+        existing_query = fs_client.collection('usuarios_estado').where('user_id', '==', user_id).stream()
+        existing_docs = list(existing_query)
+        if existing_docs:
+            doc_ref = existing_docs[0].reference
+            doc_ref.update({
+                'estado': new_status,
+                'ultima_actividad': datetime.now()
+            })
+        else:
+            fs_client.collection('usuarios_estado').add(estado_data)
+        return jsonify({'success': True, 'status': new_status})
+    except Exception as e:
+        print(f"Error updating user status: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 @status_bp.route('/get_online_users', methods=['GET'])
 def get_online_users():
-    """Obtener usuarios actualmente en línea."""
-    return jsonify({'users': []})
+    """Obtener usuarios conectados"""
+    try:
+        cutoff_time = datetime.now() - timedelta(minutes=5)
+        usuarios_query = fs_client.collection('usuarios_estado')\
+                          .where('estado', 'in', ['online', 'ocupado'])\
+                          .where('ultima_actividad', '>=', cutoff_time)
+        usuarios_estado = usuarios_query.stream()
+        users = []
+        for doc in usuarios_estado:
+            estado_data = doc.to_dict()
+            user_data = {
+                'user_id': estado_data['user_id'],
+                'estado': estado_data['estado'],
+                'ultima_actividad': estado_data['ultima_actividad'],
+                'nombre': 'Usuario'
+            }
+            try:
+                user_profile = fs_client.collection('usuarios').document(estado_data['user_id']).get()
+                if user_profile.exists:
+                    profile_data = user_profile.to_dict()
+                    user_data['nombre'] = profile_data.get('nombre_publico', 'Usuario')
+            except Exception:
+                pass
+            users.append(user_data)
+        users.sort(key=lambda x: x['ultima_actividad'], reverse=True)
+        return jsonify({'success': True, 'users': users})
+    except Exception as e:
+        print(f"Error getting online users: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/static/css/forum_projects.css
+++ b/static/css/forum_projects.css
@@ -470,3 +470,215 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* Profesiones en modal crear proyecto */
+.profesiones-container {
+    margin: 20px 0;
+}
+
+.profesiones-container label {
+    display: block;
+    margin-bottom: 12px;
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.profesiones-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+}
+
+.profesion-selector {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--glass-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 8px;
+    transition: all 0.3s ease;
+}
+
+.profesion-selector:hover {
+    background: var(--border-color);
+}
+
+.profesion-selector input[type="checkbox"] {
+    margin: 0;
+}
+
+.profesion-card {
+    flex: 1;
+    margin: 0 !important;
+    padding: 4px 8px;
+    background: transparent;
+    border: none;
+    border-radius: 16px;
+    color: var(--text-primary);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.profesion-selector input[type="checkbox"]:checked + .profesion-card {
+    background: var(--primary-color);
+    color: #000;
+    font-weight: 600;
+}
+
+.cupos-input {
+    width: 50px;
+    padding: 4px 6px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-primary);
+    text-align: center;
+    font-size: 12px;
+}
+
+.cupos-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+/* Profesiones en vista de proyecto */
+.proyecto-profesiones {
+    margin: 16px 0;
+}
+
+.profesiones-requeridas {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.profesion-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background: var(--glass-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.profesion-badge.disponible {
+    border-color: var(--primary-color);
+    background: rgba(0, 212, 184, 0.1);
+}
+
+.profesion-badge.disponible:hover {
+    background: var(--primary-color);
+    color: #000;
+    transform: scale(1.05);
+}
+
+.profesion-badge.completa {
+    background: var(--border-color);
+    color: var(--text-secondary);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.cupos-info {
+    background: var(--accent-color);
+    color: white;
+    border-radius: 10px;
+    padding: 2px 6px;
+    font-size: 10px;
+    font-weight: bold;
+}
+
+/* Selector de moneda */
+.moneda-selector {
+    display: flex;
+    gap: 12px;
+    margin: 16px 0;
+}
+
+.moneda-option {
+    flex: 1;
+    padding: 12px;
+    background: var(--glass-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.moneda-option:hover {
+    background: var(--border-color);
+}
+
+.moneda-option.selected {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: #000;
+}
+
+.moneda-simbolo {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 4px;
+    display: block;
+}
+
+.moneda-nombre {
+    font-size: 12px;
+    opacity: 0.8;
+}
+
+/* Estados de proyecto */
+.proyecto-estado {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.estado-abierto {
+    background: rgba(0, 212, 184, 0.2);
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+}
+
+.estado-en-desarrollo {
+    background: rgba(252, 211, 77, 0.2);
+    color: #F59E0B;
+    border: 1px solid #F59E0B;
+}
+
+.estado-finalizado {
+    background: rgba(107, 114, 128, 0.2);
+    color: #6B7280;
+    border: 1px solid #6B7280;
+}
+
+@media (max-width: 768px) {
+    .profesiones-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .profesion-selector {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+    }
+    
+    .moneda-selector {
+        flex-direction: column;
+    }
+}

--- a/static/css/solicitudes.css
+++ b/static/css/solicitudes.css
@@ -1,0 +1,319 @@
+/* Botón flotante de solicitudes */
+.solicitudes-btn {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    width: 60px;
+    height: 60px;
+    background: var(--primary-color);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 4px 20px rgba(0, 212, 184, 0.3);
+    transition: all 0.3s ease;
+    z-index: 999;
+    color: #000;
+}
+
+.solicitudes-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 25px rgba(0, 212, 184, 0.4);
+}
+
+.solicitudes-btn.breathing {
+    animation: breathe 2s ease-in-out infinite;
+}
+
+@keyframes breathe {
+    0%, 100% { 
+        transform: scale(1); 
+        box-shadow: 0 4px 20px rgba(0, 212, 184, 0.3);
+    }
+    50% { 
+        transform: scale(1.1); 
+        box-shadow: 0 6px 30px rgba(0, 212, 184, 0.5);
+    }
+}
+
+.solicitudes-counter {
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    background: var(--accent-color);
+    color: white;
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: bold;
+    font-family: 'Inter', sans-serif;
+}
+
+/* Panel de solicitudes */
+.solicitudes-panel {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    width: 380px;
+    max-height: 70vh;
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    z-index: 1000;
+    transform: translateX(100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.solicitudes-panel.open {
+    transform: translateX(0);
+}
+
+.solicitudes-header {
+    padding: 20px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--card-bg);
+}
+
+.solicitudes-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 24px;
+    cursor: pointer;
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: all 0.3s ease;
+}
+
+.close-btn:hover {
+    background: var(--border-color);
+    color: var(--text-primary);
+}
+
+.solicitudes-tabs {
+    display: flex;
+    background: var(--card-bg);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tab {
+    flex: 1;
+    padding: 12px 16px;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.tab:hover {
+    background: var(--border-color);
+    color: var(--text-primary);
+}
+
+.tab.active {
+    background: var(--primary-color);
+    color: #000;
+    font-weight: 600;
+}
+
+.solicitudes-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0;
+}
+
+.solicitud-item {
+    display: flex;
+    align-items: flex-start;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-color);
+    transition: background 0.3s ease;
+    gap: 12px;
+}
+
+.solicitud-item:hover {
+    background: var(--border-color);
+}
+
+.solicitud-item:last-child {
+    border-bottom: none;
+}
+
+.solicitud-icon {
+    font-size: 24px;
+    flex-shrink: 0;
+}
+
+.solicitud-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.solicitud-titulo {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+    font-size: 14px;
+}
+
+.solicitud-texto {
+    color: var(--text-secondary);
+    font-size: 13px;
+    margin-bottom: 8px;
+    line-height: 1.4;
+}
+
+.solicitud-texto strong {
+    color: var(--text-primary);
+}
+
+.profesion {
+    background: var(--primary-color);
+    color: #000;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.solicitud-mensaje {
+    font-style: italic;
+    color: var(--text-secondary);
+    font-size: 12px;
+    margin-bottom: 8px;
+    background: var(--border-color);
+    padding: 8px;
+    border-radius: 6px;
+    border-left: 3px solid var(--primary-color);
+}
+
+.solicitud-fecha {
+    font-size: 11px;
+    color: var(--text-secondary);
+    opacity: 0.7;
+}
+
+.solicitud-actions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.btn-aceptar,
+.btn-rechazar {
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: bold;
+    transition: all 0.3s ease;
+}
+
+.btn-aceptar {
+    background: var(--primary-color);
+    color: #000;
+}
+
+.btn-aceptar:hover {
+    background: #00B8A3;
+    transform: scale(1.1);
+}
+
+.btn-rechazar {
+    background: var(--accent-color);
+    color: white;
+}
+
+.btn-rechazar:hover {
+    background: #E55A2B;
+    transform: scale(1.1);
+}
+
+.no-solicitudes,
+.loading {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+/* Toast notifications */
+.toast {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%) translateY(100px);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 12px 20px;
+    color: var(--text-primary);
+    font-size: 14px;
+    z-index: 1001;
+    transition: transform 0.3s ease;
+    backdrop-filter: blur(20px);
+}
+
+.toast.show {
+    transform: translateX(-50%) translateY(0);
+}
+
+.toast-success {
+    border-left: 4px solid var(--primary-color);
+}
+
+.toast-error {
+    border-left: 4px solid var(--accent-color);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .solicitudes-panel {
+        width: calc(100vw - 40px);
+        max-width: 380px;
+    }
+    
+    .solicitudes-btn {
+        width: 50px;
+        height: 50px;
+    }
+    
+    .solicitud-item {
+        padding: 12px 16px;
+    }
+}

--- a/static/css/user_status.css
+++ b/static/css/user_status.css
@@ -1,0 +1,191 @@
+/* Selector de estado */
+.status-selector {
+    padding: 16px;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 16px;
+}
+
+.status-selector label {
+    display: block;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 600;
+}
+
+#status-select {
+    width: 100%;
+    padding: 8px 12px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 14px;
+    cursor: pointer;
+}
+
+#status-select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+/* Lista de usuarios conectados */
+.usuarios-conectados {
+    margin-bottom: 24px;
+}
+
+.usuarios-conectados h3 {
+    color: var(--text-primary);
+    font-size: 16px;
+    margin-bottom: 12px;
+    padding: 0 16px;
+}
+
+#usuarios-online-list {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.user-online-item {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
+    transition: background 0.3s ease;
+    gap: 12px;
+}
+
+.user-online-item:hover {
+    background: var(--border-color);
+}
+
+.user-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #000;
+    font-weight: bold;
+    font-size: 14px;
+    flex-shrink: 0;
+}
+
+.user-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.user-name {
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 500;
+    margin-bottom: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.user-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.status-online { background: var(--primary-color); }
+.status-ocupado { background: var(--accent-color); }
+.status-offline { background: var(--text-secondary); }
+
+.user-actions {
+    flex-shrink: 0;
+}
+
+.btn-add-friend {
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: var(--glass-bg);
+    border-radius: 50%;
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+.btn-add-friend:hover {
+    background: var(--primary-color);
+    color: #000;
+}
+
+/* Menú contextual */
+.user-context-menu {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(20px);
+    min-width: 150px;
+}
+
+.context-menu-item {
+    width: 100%;
+    padding: 12px 16px;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 14px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: background 0.3s ease;
+    text-align: left;
+}
+
+.context-menu-item:hover {
+    background: var(--border-color);
+}
+
+.no-users {
+    padding: 20px 16px;
+    text-align: center;
+    color: var(--text-secondary);
+    font-style: italic;
+    font-size: 14px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .user-online-item {
+        padding: 10px 12px;
+    }
+    
+    .user-avatar {
+        width: 32px;
+        height: 32px;
+        font-size: 12px;
+    }
+    
+    .user-name {
+        font-size: 13px;
+    }
+    
+    .user-status {
+        font-size: 11px;
+    }
+}

--- a/static/js/forum_projects.js
+++ b/static/js/forum_projects.js
@@ -587,3 +587,36 @@ style.textContent = `
 `;
 document.head.appendChild(style);
 
+// Agregar profesionales al modal de crear proyecto
+function actualizarModalProyecto() {
+    const modal = document.getElementById('project-modal');
+    const profesionesContainer = document.createElement('div');
+    profesionesContainer.className = 'profesiones-container';
+    profesionesContainer.innerHTML = `
+        <label>Profesiones requeridas:</label>
+        <div class="profesiones-grid">
+            ${PROFESIONES_DISPONIBLES.map(prof => `
+                <div class="profesion-selector" data-profesion="${prof}">
+                    <input type="checkbox" id="prof-${prof}" name="profesiones" value="${prof}">
+                    <label for="prof-${prof}" class="profesion-card">${prof}</label>
+                    <input type="number" class="cupos-input" min="1" max="10" value="1" 
+                           placeholder="Cupos" title="Número de cupos para ${prof}">
+                </div>
+            `).join('')}
+        </div>
+    `;
+    const descripcionField = modal.querySelector('textarea[name="descripcion"]').parentNode;
+    descripcionField.after(profesionesContainer);
+}
+
+const PROFESIONES_DISPONIBLES = [
+    "Editor", "Animador 3D", "Camarógrafo", "Narrador de voz",
+    "Fotógrafo", "Sonidista", "Guionista", "Doblaje", "Creador de contenido"
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('project-modal')) {
+        actualizarModalProyecto();
+    }
+});
+

--- a/static/js/solicitudes_manager.js
+++ b/static/js/solicitudes_manager.js
@@ -1,0 +1,313 @@
+class SolicitudesManager {
+    constructor() {
+        this.panel = null;
+        this.button = null;
+        this.contador = 0;
+        this.solicitudes = [];
+        this.isPolling = false;
+        this.init();
+    }
+
+    init() {
+        this.createButton();
+        this.createPanel();
+        this.loadSolicitudes();
+        this.startPolling();
+        this.setupEventListeners();
+    }
+
+    createButton() {
+        // Crear botón flotante con contador
+        this.button = document.createElement('div');
+        this.button.className = 'solicitudes-btn';
+        this.button.innerHTML = `
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20 6L9 17l-5-5"/>
+            </svg>
+            <div class="solicitudes-counter" style="display: none;">0</div>
+        `;
+        
+        document.body.appendChild(this.button);
+        
+        this.button.addEventListener('click', () => this.togglePanel());
+    }
+
+    createPanel() {
+        this.panel = document.createElement('div');
+        this.panel.className = 'solicitudes-panel';
+        this.panel.innerHTML = `
+            <div class="solicitudes-header">
+                <h3>Solicitudes</h3>
+                <button class="close-btn">&times;</button>
+            </div>
+            <div class="solicitudes-content">
+                <div class="solicitudes-tabs">
+                    <button class="tab active" data-tab="proyectos">📁 Proyectos</button>
+                    <button class="tab" data-tab="amigos">👤 Amigos</button>
+                </div>
+                <div class="solicitudes-list">
+                    <div class="loading">Cargando solicitudes...</div>
+                </div>
+            </div>
+        `;
+        
+        document.body.appendChild(this.panel);
+    }
+
+    setupEventListeners() {
+        // Cerrar panel
+        this.panel.querySelector('.close-btn').addEventListener('click', () => {
+            this.closePanel();
+        });
+
+        // Tabs
+        this.panel.querySelectorAll('.tab').forEach(tab => {
+            tab.addEventListener('click', (e) => {
+                this.switchTab(e.target.dataset.tab);
+            });
+        });
+
+        // Cerrar al hacer click fuera
+        document.addEventListener('click', (e) => {
+            if (!this.panel.contains(e.target) && !this.button.contains(e.target)) {
+                this.closePanel();
+            }
+        });
+    }
+
+    async loadSolicitudes() {
+        try {
+            // Cargar solicitudes de proyectos
+            const proyectosResponse = await fetch('/projects/get_project_requests');
+            const proyectosSolicitudes = await proyectosResponse.json();
+
+            // Cargar solicitudes de amistad
+            const amigosResponse = await fetch('/friends/get_friend_requests');
+            const amigosSolicitudes = await amigosResponse.json();
+
+            this.solicitudes = {
+                proyectos: proyectosSolicitudes.solicitudes || [],
+                amigos: amigosSolicitudes.solicitudes || []
+            };
+
+            this.updateContador();
+            this.renderSolicitudes();
+
+        } catch (error) {
+            console.error('Error loading solicitudes:', error);
+        }
+    }
+
+    updateContador() {
+        const total = (this.solicitudes.proyectos.length + this.solicitudes.amigos.length);
+        const counter = this.button.querySelector('.solicitudes-counter');
+        
+        if (total > 0) {
+            counter.textContent = total;
+            counter.style.display = 'flex';
+            this.startBreathing();
+        } else {
+            counter.style.display = 'none';
+            this.stopBreathing();
+        }
+        
+        this.contador = total;
+    }
+
+    startBreathing() {
+        this.button.classList.add('breathing');
+    }
+
+    stopBreathing() {
+        this.button.classList.remove('breathing');
+    }
+
+    renderSolicitudes() {
+        const activeTab = this.panel.querySelector('.tab.active').dataset.tab;
+        const container = this.panel.querySelector('.solicitudes-list');
+        
+        const solicitudes = this.solicitudes[activeTab] || [];
+        
+        if (solicitudes.length === 0) {
+            container.innerHTML = '<div class="no-solicitudes">No hay solicitudes pendientes</div>';
+            return;
+        }
+
+        container.innerHTML = solicitudes.map(solicitud => {
+            if (activeTab === 'proyectos') {
+                return this.renderSolicitudProyecto(solicitud);
+            } else {
+                return this.renderSolicitudAmigo(solicitud);
+            }
+        }).join('');
+
+        // Agregar event listeners a los botones
+        this.setupSolicitudButtons();
+    }
+
+    renderSolicitudProyecto(solicitud) {
+        return `
+            <div class="solicitud-item proyecto" data-id="${solicitud.id}">
+                <div class="solicitud-icon">📁</div>
+                <div class="solicitud-content">
+                    <div class="solicitud-titulo">${solicitud.proyecto_titulo}</div>
+                    <div class="solicitud-texto">
+                        <strong>${solicitud.solicitante_nombre}</strong> quiere unirse como 
+                        <span class="profesion">${solicitud.profesion_solicitada}</span>
+                    </div>
+                    <div class="solicitud-mensaje">"${solicitud.mensaje}"</div>
+                    <div class="solicitud-fecha">${this.formatFecha(solicitud.fecha_solicitud)}</div>
+                </div>
+                <div class="solicitud-actions">
+                    <button class="btn-aceptar" data-action="accept" data-type="proyecto" data-id="${solicitud.id}">
+                        ✓
+                    </button>
+                    <button class="btn-rechazar" data-action="reject" data-type="proyecto" data-id="${solicitud.id}">
+                        ✗
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    renderSolicitudAmigo(solicitud) {
+        return `
+            <div class="solicitud-item amigo" data-id="${solicitud.id}">
+                <div class="solicitud-icon">👤</div>
+                <div class="solicitud-content">
+                    <div class="solicitud-titulo">Solicitud de Amistad</div>
+                    <div class="solicitud-texto">
+                        <strong>${solicitud.solicitante_nombre}</strong> quiere agregarte como amigo
+                    </div>
+                    <div class="solicitud-fecha">${this.formatFecha(solicitud.fecha_solicitud)}</div>
+                </div>
+                <div class="solicitud-actions">
+                    <button class="btn-aceptar" data-action="accept" data-type="amigo" data-id="${solicitud.id}">
+                        ✓
+                    </button>
+                    <button class="btn-rechazar" data-action="reject" data-type="amigo" data-id="${solicitud.id}">
+                        ✗
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    setupSolicitudButtons() {
+        this.panel.querySelectorAll('[data-action]').forEach(button => {
+            button.addEventListener('click', async (e) => {
+                const action = e.target.dataset.action;
+                const type = e.target.dataset.type;
+                const id = e.target.dataset.id;
+                
+                await this.handleSolicitudAction(action, type, id);
+            });
+        });
+    }
+
+    async handleSolicitudAction(action, type, id) {
+        try {
+            let endpoint = '';
+            if (type === 'proyecto') {
+                endpoint = `/projects/respond_project_request`;
+            } else {
+                endpoint = `/friends/respond_friend_request`;
+            }
+
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    solicitud_id: id,
+                    accion: action === 'accept' ? 'aceptar' : 'rechazar'
+                })
+            });
+
+            const result = await response.json();
+            
+            if (result.success) {
+                // Mostrar toast de confirmación
+                this.showToast(`Solicitud ${action === 'accept' ? 'aceptada' : 'rechazada'} correctamente`, 'success');
+                
+                // Recargar solicitudes
+                await this.loadSolicitudes();
+            } else {
+                this.showToast('Error al procesar solicitud', 'error');
+            }
+
+        } catch (error) {
+            console.error('Error handling solicitud:', error);
+            this.showToast('Error de conexión', 'error');
+        }
+    }
+
+    switchTab(tab) {
+        // Actualizar tabs activos
+        this.panel.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        this.panel.querySelector(`[data-tab="${tab}"]`).classList.add('active');
+        
+        // Renderizar solicitudes del tab seleccionado
+        this.renderSolicitudes();
+    }
+
+    togglePanel() {
+        if (this.panel.classList.contains('open')) {
+            this.closePanel();
+        } else {
+            this.openPanel();
+        }
+    }
+
+    openPanel() {
+        this.panel.classList.add('open');
+        this.stopBreathing();
+        this.loadSolicitudes();
+    }
+
+    closePanel() {
+        this.panel.classList.remove('open');
+    }
+
+    startPolling() {
+        if (this.isPolling) return;
+        
+        this.isPolling = true;
+        setInterval(() => {
+            if (!this.panel.classList.contains('open')) {
+                this.loadSolicitudes();
+            }
+        }, 30000); // Polling cada 30 segundos
+    }
+
+    formatFecha(fecha) {
+        const date = new Date(fecha);
+        const now = new Date();
+        const diff = now - date;
+        
+        if (diff < 60000) return 'Hace un momento';
+        if (diff < 3600000) return `Hace ${Math.floor(diff/60000)} minutos`;
+        if (diff < 86400000) return `Hace ${Math.floor(diff/3600000)} horas`;
+        return `Hace ${Math.floor(diff/86400000)} días`;
+    }
+
+    showToast(message, type = 'info') {
+        const toast = document.createElement('div');
+        toast.className = `toast toast-${type}`;
+        toast.textContent = message;
+        
+        document.body.appendChild(toast);
+        
+        setTimeout(() => toast.classList.add('show'), 100);
+        setTimeout(() => {
+            toast.classList.remove('show');
+            setTimeout(() => toast.remove(), 300);
+        }, 3000);
+    }
+}
+
+// Inicializar cuando el DOM esté listo
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.currentUser && window.currentUser.authenticated) {
+        new SolicitudesManager();
+    }
+});

--- a/static/js/user_status.js
+++ b/static/js/user_status.js
@@ -1,0 +1,268 @@
+class UserStatusManager {
+    constructor() {
+        this.currentStatus = 'online';
+        this.heartbeatInterval = null;
+        this.init();
+    }
+
+    init() {
+        this.createStatusSelector();
+        this.startHeartbeat();
+        this.setupEventListeners();
+        this.loadOnlineUsers();
+    }
+
+    createStatusSelector() {
+        // Verificar si ya existe
+        if (document.getElementById('user-status-selector')) return;
+
+        const selector = document.createElement('div');
+        selector.id = 'user-status-selector';
+        selector.className = 'status-selector';
+        selector.innerHTML = `
+            <label for="status-select">Estado:</label>
+            <select id="status-select">
+                <option value="online">🟢 En línea</option>
+                <option value="ocupado">🟡 Ocupado</option>
+                <option value="offline">⚫ Desconectado</option>
+            </select>
+        `;
+
+        const sidebar = document.querySelector('.forum-sidebar') || 
+                       document.querySelector('.dashboard-sidebar') ||
+                       document.querySelector('.sidebar');
+        
+        if (sidebar) {
+            sidebar.appendChild(selector);
+        }
+    }
+
+    setupEventListeners() {
+        const statusSelect = document.getElementById('status-select');
+        if (statusSelect) {
+            statusSelect.addEventListener('change', (e) => {
+                this.updateStatus(e.target.value);
+            });
+        }
+
+        let inactivityTimer;
+        const resetTimer = () => {
+            clearTimeout(inactivityTimer);
+            inactivityTimer = setTimeout(() => {
+                if (this.currentStatus === 'online') {
+                    this.updateStatus('ocupado', false);
+                }
+            }, 300000);
+        };
+
+        ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'].forEach(event => {
+            document.addEventListener(event, resetTimer, true);
+        });
+    }
+
+    async updateStatus(newStatus, updateSelector = true) {
+        try {
+            const response = await fetch('/status/update_status', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ status: newStatus })
+            });
+
+            const result = await response.json();
+            if (result.success) {
+                this.currentStatus = newStatus;
+                
+                if (updateSelector) {
+                    const statusSelect = document.getElementById('status-select');
+                    if (statusSelect) {
+                        statusSelect.value = newStatus;
+                    }
+                }
+
+                this.updateUIStatus(newStatus);
+                this.loadOnlineUsers();
+            }
+        } catch (error) {
+            console.error('Error updating status:', error);
+        }
+    }
+
+    updateUIStatus(status) {
+        const statusIndicators = document.querySelectorAll('.my-status-indicator');
+        statusIndicators.forEach(indicator => {
+            indicator.className = `my-status-indicator status-${status}`;
+        });
+    }
+
+    async loadOnlineUsers() {
+        try {
+            const response = await fetch('/status/get_online_users');
+            const result = await response.json();
+            
+            if (result.success) {
+                this.renderOnlineUsers(result.users);
+            }
+        } catch (error) {
+            console.error('Error loading online users:', error);
+        }
+    }
+
+    renderOnlineUsers(users) {
+        const container = document.getElementById('usuarios-online-list');
+        if (!container) return;
+
+        if (users.length === 0) {
+            container.innerHTML = '<div class="no-users">No hay usuarios conectados</div>';
+            return;
+        }
+
+        container.innerHTML = users.map(user => `
+            <div class="user-online-item" data-user-id="${user.user_id}">
+                <div class="user-avatar">
+                    ${user.nombre ? user.nombre.charAt(0).toUpperCase() : 'U'}
+                </div>
+                <div class="user-info">
+                    <div class="user-name">${user.nombre || 'Usuario'}</div>
+                    <div class="user-status">
+                        <span class="status-indicator status-${user.estado}"></span>
+                        ${this.getStatusText(user.estado)}
+                    </div>
+                </div>
+                <div class="user-actions">
+                    <button class="btn-add-friend" onclick="showUserActions('${user.user_id}', this)">
+                        ⋯
+                    </button>
+                </div>
+            </div>
+        `).join('');
+
+        this.setupUserInteractions();
+    }
+
+    setupUserInteractions() {
+        const userItems = document.querySelectorAll('.user-online-item');
+        userItems.forEach(item => {
+            item.addEventListener('click', (e) => {
+                if (!e.target.closest('.user-actions')) {
+                    const userId = item.dataset.userId;
+                    this.showUserProfile(userId, e.target);
+                }
+            });
+        });
+    }
+
+    showUserProfile(userId, element) {
+        console.log('Showing profile for user:', userId);
+    }
+
+    getStatusText(status) {
+        const statusTexts = {
+            'online': 'En línea',
+            'ocupado': 'Ocupado',
+            'offline': 'Desconectado'
+        };
+        return statusTexts[status] || 'Desconocido';
+    }
+
+    startHeartbeat() {
+        this.heartbeatInterval = setInterval(() => {
+            if (this.currentStatus !== 'offline') {
+                this.updateStatus(this.currentStatus, false);
+            }
+        }, 30000);
+    }
+
+    destroy() {
+        if (this.heartbeatInterval) {
+            clearInterval(this.heartbeatInterval);
+        }
+    }
+}
+
+function showUserActions(userId, button) {
+    const existingMenu = document.querySelector('.user-context-menu');
+    if (existingMenu) {
+        existingMenu.remove();
+    }
+
+    const menu = document.createElement('div');
+    menu.className = 'user-context-menu';
+    menu.innerHTML = `
+        <button onclick="sendFriendRequest('${userId}')" class="context-menu-item">
+            👤 Agregar amigo
+        </button>
+        <button onclick="sendMessage('${userId}')" class="context-menu-item">
+            💬 Enviar mensaje
+        </button>
+    `;
+
+    document.body.appendChild(menu);
+
+    const rect = button.getBoundingClientRect();
+    menu.style.position = 'absolute';
+    menu.style.top = (rect.bottom + window.scrollY) + 'px';
+    menu.style.left = (rect.left + window.scrollX) + 'px';
+    menu.style.zIndex = '1001';
+
+    setTimeout(() => {
+        document.addEventListener('click', function closeMenu(e) {
+            if (!menu.contains(e.target)) {
+                menu.remove();
+                document.removeEventListener('click', closeMenu);
+            }
+        });
+    }, 100);
+}
+
+async function sendFriendRequest(userId) {
+    try {
+        const response = await fetch('/friends/send_friend_request', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ receptor_id: userId })
+        });
+
+        const result = await response.json();
+        if (result.success) {
+            showToast('Solicitud de amistad enviada', 'success');
+        } else {
+            showToast(result.error || 'Error al enviar solicitud', 'error');
+        }
+    } catch (error) {
+        showToast('Error de conexión', 'error');
+    }
+
+    document.querySelector('.user-context-menu')?.remove();
+}
+
+function sendMessage(userId) {
+    console.log('Opening chat with user:', userId);
+    showToast('Función de chat en desarrollo', 'info');
+    document.querySelector('.user-context-menu')?.remove();
+}
+
+function showToast(message, type = 'info') {
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.textContent = message;
+    
+    document.body.appendChild(toast);
+    
+    setTimeout(() => toast.classList.add('show'), 100);
+    setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 300);
+    }, 3000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.currentUser && window.currentUser.authenticated) {
+        window.userStatusManager = new UserStatusManager();
+    }
+});
+
+window.addEventListener('beforeunload', () => {
+    if (window.userStatusManager) {
+        window.userStatusManager.destroy();
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,8 @@
   <link rel="stylesheet" href="/static/style.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/site.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/home_brutalista.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/solicitudes.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/user_status.css') }}">
   {% block head_admin %}{% endblock %}
   {% block extra_head %}{% endblock %}
 </head>
@@ -28,5 +30,15 @@
   <script src="{{ url_for('static', filename='js/title-rotator.js') }}"></script>
   {% endif %}
   <script src="{{ url_for('static', filename='js/nav.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/solicitudes_manager.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/user_status.js') }}"></script>
+
+  <script>
+    window.currentUser = {
+        authenticated: {% if session.get('user_id') %}true{% else %}false{% endif %},
+        user_id: "{{ session.get('user_id', '') }}",
+        user_name: "{{ session.get('user_name', '') }}"
+    };
+  </script>
 </body>
 </html>

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -265,12 +265,18 @@
                     <strong style="color:var(--text-primary);">Plugins de masterización</strong><br>
                     Comparativa de herramientas profesionales
                 </div>
-                <div style="font-size:13px; color:var(--text-secondary); line-height:1.4;">
-                    <strong style="color:var(--text-primary);">Workflow multicámara</strong><br>
-                    Sincronización eficiente de audio
-                </div>
+            <div style="font-size:13px; color:var(--text-secondary); line-height:1.4;">
+                <strong style="color:var(--text-primary);">Workflow multicámara</strong><br>
+                Sincronización eficiente de audio
             </div>
         </div>
+        <div class="usuarios-conectados">
+            <h3>Miembros Conectados</h3>
+            <div id="usuarios-online-list">
+                <div class="loading">Cargando usuarios...</div>
+            </div>
+        </div>
+    </div>
     </aside>
     {% if session.forum_user %}
     <div class="user-status" style="position: fixed; bottom: 20px; right: 20px; background: var(--bg-secondary); padding: 1rem; border-radius: 12px;">
@@ -422,6 +428,8 @@
 {{ super() }}
 <script src="{{ url_for('static', filename='js/forum_modern.js') }}"></script>
 <script src="{{ url_for('static', filename='js/forum_projects.js') }}"></script>
+<script src="{{ url_for('static', filename='js/user_status.js') }}"></script>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/user_status.css') }}">
 {% if session.forum_user %}
 <div data-user-id="{{ session.forum_user.id }}" style="display: none;"></div>
 {% endif %}


### PR DESCRIPTION
## Summary
- add frontend assets for solicitudes and user status management
- integrate professions UI for projects
- implement new endpoints for projects, friends, and user status
- update templates with new scripts, styles, and online users list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_687a7e6b06d48325920c052564462ce9