### PR TITLE
Implement forum registration endpoint

### DIFF
--- a/static/js/vforum_register.js
+++ b/static/js/vforum_register.js
@@ -1,0 +1,24 @@
+document.querySelector('#register-form')?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    username: e.target.username.value,
+    email:    e.target.email.value,
+    password: e.target.password.value
+  };
+
+  try {
+    const res = await fetch('/forum/register', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    });
+    const json = await res.json();
+    if (json.success) {
+      window.location.href = '/forum';
+    } else {
+      alert(json.error || 'Error');
+    }
+  } catch (err) {
+    alert('Error de conexión');
+  }
+});

--- a/templates/vforum_auth.html
+++ b/templates/vforum_auth.html
@@ -182,7 +182,7 @@
 
         <!-- Formulario de Registro -->
         <div id="registerForm" class="form-container">
-            <form onsubmit="handleRegister(event)">
+            <form id="register-form">
                 <div class="form-group">
                     <input type="text" name="username" class="form-input" 
                            placeholder="Nombre de usuario" required>
@@ -287,28 +287,6 @@ function toggleForms() {
     }
 }
 
-// Manejo de registro
-async function handleRegister(event) {
-    event.preventDefault();
-    const formData = new FormData(event.target);
-    
-    try {
-        const response = await fetch('/forum/register', {
-            method: 'POST',
-            body: formData
-        });
-        
-        const data = await response.json();
-        
-        if (data.success) {
-            window.location.href = data.redirect;
-        } else {
-            alert(data.error || 'Error al registrar');
-        }
-    } catch (error) {
-        alert('Error de conexión');
-    }
-}
 
 // Manejo de login
 async function handleLogin(event) {
@@ -333,4 +311,9 @@ async function handleLogin(event) {
     }
 }
 </script>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/vforum_register.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create `/forum/register` endpoint (`register_user`)
- load Firestore client in `forum_auth` and manage session
- add JS to handle registration via JSON
- adapt authentication template to use new JS file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687af3b2db7c832591cb07e9c26a2696