### PR TITLE
Add /projects/create endpoint

### DIFF
--- a/static/js/forum_projects.js
+++ b/static/js/forum_projects.js
@@ -310,17 +310,25 @@ class ProjectsManager {
     }
 
     async submitProject(event) {
-        const formData = new FormData(event.target);
-        formData.set('tags', JSON.stringify(this.tags));
+        const payload = {
+            titulo:       event.target.titulo.value,
+            categoria:    event.target.categoria.value,
+            presupuesto:  event.target.presupuesto.value,
+            descripcion:  event.target.descripcion.value,
+            duracion:     event.target.duracion_estimada.value,
+            roles:        event.target.roles_necesarios.value.split(',').map(r => r.trim()).filter(Boolean),
+            tags:         this.tags || []
+        };
 
         try {
-            const response = await fetch('/api/projects/create', {
+            const response = await fetch('/projects/create', {
                 method: 'POST',
-                body: formData
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(payload)
             });
 
             const data = await response.json();
-            
+
             if (data.success) {
                 this.closeProjectModal();
                 this.loadProjects();


### PR DESCRIPTION
## Summary
- add `/projects/create` route for posting projects
- update JS to send JSON payload to new endpoint
- keep previous API route as `create_project_api`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687af6a2d5f48325a2710b0ca7527e86