### PR TITLE
Slow down login banner fade cycle

### DIFF
--- a/templates/vforum_auth.html
+++ b/templates/vforum_auth.html
@@ -147,7 +147,7 @@
 /* Animaciones */
 .fade-rotate {
     opacity: 0;
-    animation: fadeRotate 1s ease forwards;
+    animation: fadeRotate 1.6s ease forwards;
 }
 
 @keyframes fadeRotate {
@@ -269,7 +269,7 @@ function rotateLoginPhrase() {
     }, 100);
 }
 
-setInterval(rotateLoginPhrase, 3000);
+setInterval(rotateLoginPhrase, 9000);
 
 // Toggle entre formularios
 document.getElementById('loginPhrase').addEventListener('click', toggleForms);


### PR DESCRIPTION
## Summary
- extend animation timing for login phrase transitions
- rotate login phrases every 9 seconds instead of 3

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687afae8b43c8325abee879d314f820c