### PR TITLE
Implement dual theme with neon effects

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,15 +1,34 @@
 :root {
+  /* DARK (NEÓN) */
   --bg: #0f172a;
   --fg: #f8fafc;
   --card: #1e293b;
   --accent: #10b981;
+  --accent-2: #0ea5e9;          /* para links */
+  --glow: 0 0 8px var(--accent), 0 0 16px var(--accent-2);
+  --shadow: 0 1px 3px rgba(0,0,0,.3);
 }
-:root[data-theme=light] {
-  --bg: #f8fafc;
-  --fg: #0f172a;
-  --card: #e2e8f0;
-  --accent: #0e7490;
+:root[data-theme="light"] {
+  /* LIGHT (PALETA AD-HOC OPAL / JADE) */
+  --bg: #fdfdfd;
+  --fg: #1e293b;
+  --card: #e7eff6;              /* cristal opaco suave */
+  --accent: #157a6e;            /* jade */
+  --accent-2: #1d4ed8;          /* índigo */
+  --glow: none;                 /* sin neón */
+  --shadow: 0 2px 6px rgba(0,0,0,.15);
 }
-body { background: var(--bg); color: var(--fg); }
-.card { background: var(--card); }
-a { color: var(--accent); }
+
+body   { background: var(--bg); color: var(--fg); transition: background .3s,color .3s; }
+a      { color: var(--accent-2); }
+.card  { background: var(--card); box-shadow: var(--shadow); border-radius: .75rem; }
+
+.breathing-neon { box-shadow: var(--glow); }
+.animate-neon  { animation: breath 2s ease-in-out infinite; }
+[data-theme="light"] .animate-neon { animation: none; } /* quita glow en light */
+
+@keyframes breath {
+  0%,100%{ box-shadow: var(--glow); } 50%{ box-shadow: 0 0 4px var(--accent); }
+}
+
+.toast-info, .btn-aceptar, .btn-rechazar { box-shadow: var(--shadow); } /* botones / toasts en light */

--- a/static/js/nav_behaviour.js
+++ b/static/js/nav_behaviour.js
@@ -29,5 +29,9 @@
     root.dataset.theme = t;
     localStorage.setItem('theme', t);
     btn.textContent = t === 'dark' ? '🌙' : '☀️';
+    document.querySelectorAll('.breathing-neon').forEach(el=>{
+        if(t==='dark'){ el.classList.add('animate-neon'); }
+        else          { el.classList.remove('animate-neon'); }
+    });
   }
 })();

--- a/templates/_glass_nav.html
+++ b/templates/_glass_nav.html
@@ -1,7 +1,7 @@
 <nav id="glass-nav" class="fixed top-0 inset-x-0 z-50 \
           bg-black/50 backdrop-blur-lg transition-transform duration-300">
   <div class="max-w-7xl mx-auto flex items-center justify-between px-6 py-3">
-    <a href="/" class="text-2xl font-extrabold text-white">VERITÉ</a>
+    <a href="/" class="text-2xl font-extrabold breathing-neon">VERITÉ</a>
     <ul class="flex gap-6 text-gray-200">
       <li><a href="/">Inicio</a></li>
       <li><a href="/dashboard">Mis proyectos</a></li>


### PR DESCRIPTION
## Summary
- style root variables for dark neon and light modes
- animate neon glow via `animate-neon` class
- update glass navigation logo to use breathing-neon style
- toggle neon animation on theme switch

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687b010cde9483259fed22f16f5eceb1