### PR TITLE
Remove global button style from header nav

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -93,6 +93,11 @@ body {
   text-decoration: none;
   text-transform: uppercase;
   transition: color 0.3s ease, text-shadow 0.3s ease;
+  background: transparent !important;
+  padding: 0.5rem 0 !important;
+  margin-top: 0 !important;
+  border-radius: 0 !important;
+  border: none !important;
 }
 
 .header-unified nav a:hover {


### PR DESCRIPTION
## Summary
- override global `a` styles so header links remain transparent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=3.0)*

------
https://chatgpt.com/codex/tasks/task_e_687bc58b2f388325a915eaff3df2a7af