### PR TITLE
Modifica logo-unified para coincidir con nav global

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -76,9 +76,10 @@ body {
   font-family: 'Poppins', sans-serif;
   font-weight: 900;
   font-size: 1.5rem;
-  color: var(--primary-color);
+  color: #FFFFFF;
   text-decoration: none;
-  transition: transform 0.3s ease;
+  text-transform: uppercase;
+  transition: color 0.3s ease, transform 0.3s ease;
 }
 
 .logo-unified:hover {


### PR DESCRIPTION
## Summary
- aplicamos el mismo estilo base de los enlaces globales en `.logo-unified`
- el logo ahora usa mayúsculas blancas y transición suave con escala al pasar el cursor

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687bd45a4c34832580ba05152cbd9e5d