### PR TITLE
Fix Python & Flask version

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,5 +5,7 @@ services:
     buildCommand: "pip install -r requirements.txt"
     startCommand: "gunicorn app:app"
     envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.9
       - key: SECRET_KEY
         generateValue: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.1.2
+Flask==3.1.1
 Flask-Login==0.7.0
 gunicorn==22.0.0
 Werkzeug>=3.0


### PR DESCRIPTION
## Summary
- pin Flask 3.1.1
- specify Python 3.11.9 in render config

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==3.1.1)*
- `flask --app app run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c86bd4d8c8325b9e57005d9ee2fc8