### PR TITLE
Hotfix: adjust python and Flask-Login versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.1
-Flask-Login==0.7.0
+Flask-Login==0.6.3
 gunicorn==22.0.0
 Werkzeug>=3.0


### PR DESCRIPTION
## Summary
- pin Flask-Login to `0.6.3`
- confirm Render uses Python `3.11.9`
- keep runtime configuration for buildpack

## Testing
- `python -m venv .venv && source .venv/bin/activate`
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*
- `flask --app app run` *(not run due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_687c886e86488325a7314fbc6f48fb9b