### PR TITLE
Add Flask-Migrate and Alembic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ SQLAlchemy>=2.0
 psycopg2-binary>=2.9
 gunicorn==22.0.0
 Werkzeug>=3.0
+
+Flask-Migrate==4.0.5
+Alembic>=1.13


### PR DESCRIPTION
## Summary
- include Flask-Migrate and Alembic in requirements.txt

## Testing
- `python3 -m venv .venv`
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*
- `flask --app app db upgrade` *(fails: command not found)*
- `flask --app app run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8c9159bc8325963489571f023e7f