### PR TITLE
hotfix: add Google Cloud dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,10 @@ Werkzeug>=3.0
 
 Flask-Migrate==4.0.5
 Alembic>=1.13
+
+# Google Cloud core dependencies
+google-api-core>=2.18
+google-auth>=2.29
+
+# Firestore client
+google-cloud-firestore>=2.14


### PR DESCRIPTION
## Summary
- include google-api-core and google-auth
- include google-cloud-firestore for Firestore access

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687c8ebcd66883259f2bfd6c8890e4d2