### PR TITLE
Fix missing Google API dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,7 @@ google-api-core>=2.18
 google-auth>=2.29
 
 # Firestore client
-google-cloud-firestore>=2.14
+google-cloud-firestore>=2.16
+
+# Google API client (for Drive previews)
+google-api-python-client>=2.127


### PR DESCRIPTION
## Summary
- include `google-api-python-client` for Drive previews
- bump Firestore client to 2.16

## Testing
- `pytest -q` *(fails: `pyenv: version '3.11.9' is not installed`)*

------
https://chatgpt.com/codex/tasks/task_e_687c923c27d88325bf7d2af712740d64