### PR TITLE
Add chat modal to base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,5 +44,9 @@
         user_name: "{{ session.get('user_name', '') }}"
     };
   </script>
+  {# --- Chat modal --- #}
+  {% include 'forum/chat_modal.html' %}
+
+  <script src="{{ url_for('static', filename='js/chat.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include chat modal in `base.html`
- load `chat.js` in master template

## Testing
- `pytest -q` *(fails: Python 3.11.9 missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d19c69f1083258932be21347d8782