### PR TITLE
Replace chat modal with floating widget

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -29,8 +29,16 @@ class ChatManager {
     });
   }
 
+  _show() {
+    this.widget.classList.remove('invisible', 'opacity-0', 'translate-y-4');
+  }
+  _hide() {
+    this.widget.classList.add('opacity-0', 'translate-y-4');
+    setTimeout(() => this.widget.classList.add('invisible'), 300);
+  }
+
   open(chatId, targetName) {
-    this.widget.classList.remove('hidden');
+    this._show();
     this.title.textContent = targetName ?? 'Chat';
     this.chatId = chatId;
     this.loadMessages();
@@ -38,7 +46,7 @@ class ChatManager {
   }
 
   close() {
-    this.widget.classList.add('hidden');
+    this._hide();
     if (this.pollId) clearInterval(this.pollId);
   }
 
@@ -47,9 +55,19 @@ class ChatManager {
       const res = await fetch(`/chat/get_messages/${this.chatId}`);
       const data = await res.json();
       if (!data.success) { console.error(data.error); return this.close(); }
-      this.msgBox.innerHTML = data.messages.map(m =>
-        `<div><span class="font-semibold">${m.autor_nombre}:</span> ${m.mensaje}</div>`
-      ).join('');
+      const uid = window.currentUser.user_id;
+      this.msgBox.innerHTML = data.messages.map(m => {
+        const own = m.autor_id === uid;
+        const base = 'inline-block max-w-[70%] px-3 py-1 rounded-lg break-words';
+        const bubble = own
+          ? `self-end bg-primary text-white rounded-br-none ${base}`
+          : `self-start bg-neutral-700 rounded-bl-none ${base}`;
+        return `<div class="flex ${own ? 'justify-end' : 'justify-start'}">
+                  <span class="${bubble}">
+                    <span class="font-semibold">${m.autor_nombre}:</span> ${m.mensaje}
+                  </span>
+                </div>`;
+      }).join('');
       this.msgBox.scrollTop = this.msgBox.scrollHeight;
     } catch (err) {
       console.error('loadMessages', err);

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,7 +45,7 @@
     };
   </script>
   {# --- Chat modal --- #}
-  {% include 'forum/chat_modal.html' %}
+  {% include 'forum/chat_widget.html' %}
 
   <script src="{{ url_for('static', filename='js/chat.js') }}"></script>
 </body>

--- a/templates/forum/chat_widget.html
+++ b/templates/forum/chat_widget.html
@@ -1,0 +1,42 @@
+<!-- Ventana flotante de chat -->
+<div id="chat-widget"
+     class="fixed bottom-20 right-6 z-50 w-80 max-h-[70vh] bg-neutral-800 text-gray-100
+            rounded-xl shadow-2xl ring-1 ring-neutral-700 flex flex-col
+            invisible opacity-0 translate-y-4 transition-all duration-300">
+
+  <!-- CABECERA -->
+  <header class="flex items-center justify-between bg-neutral-900 px-3 py-2 rounded-t-xl">
+    <h3 id="chat-title" class="text-sm font-semibold truncate">Chat</h3>
+    <button id="chat-close-btn"
+            class="text-sm hover:text-red-400 focus:outline-none">✖</button>
+  </header>
+
+  <!-- MENSAJES -->
+  <section id="chat-messages"
+           class="flex-1 overflow-y-auto px-3 py-2 space-y-2 text-sm
+                  scrollbar-thin scrollbar-thumb-neutral-600 scrollbar-track-transparent"></section>
+
+  <!-- PIE -->
+  <footer class="border-t border-neutral-700 p-2 flex items-end gap-1">
+    <!-- emoji -->
+    <button id="emoji-btn"
+            class="text-xl leading-none hover:scale-110 transition-transform">😊</button>
+
+    <!-- input -->
+    <textarea id="chat-input" rows="1" placeholder="Escribe… Ctrl+Enter"
+              class="flex-1 bg-transparent resize-none focus:outline-none
+                     placeholder-neutral-400"></textarea>
+
+    <!-- send -->
+    <button id="send-btn"
+            class="text-lg px-2 py-1 hover:text-green-400 transition-colors">➤</button>
+
+    <!-- picker -->
+    <div id="emoji-picker"
+         class="absolute bottom-14 right-2 bg-neutral-800 border border-neutral-600 rounded-lg
+                p-2 grid grid-cols-5 gap-1 text-xl hidden">
+      😊 😂 😍 🤔 🙄 😢 😎 🤩 😡 👍
+      👎 🙌 🤝 🙏 💡 🚀 🐱 🎉 🍀 ⚽
+    </div>
+  </footer>
+</div>


### PR DESCRIPTION
## Summary
- add new `chat_widget.html` with slide-up style
- update base template to use the new chat widget
- enhance JS chat manager with show/hide helpers and modern message bubbles

## Testing
- `pytest -q` *(fails: pyenv 3.11.9 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d2557eb2c8325b623cdd51366637e