### PR TITLE
Remove unused chat widget

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,11 +44,5 @@
         user_name: "{{ session.get('user_name', '') }}"
     };
   </script>
-  {# --- Chat modal --- #}
-  <div id="chat-root"></div>
-  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script type="text/babel" src="{{ url_for('static', filename='js/chat_modal.jsx') }}"></script>
 </body>
 </html>

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -234,11 +234,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <div class="user-status" style="position: fixed; bottom: 20px; right: 20px; background: var(--bg-secondary); padding: 1rem; border-radius: 12px;">
         <img src="{{ session.forum_user.profile_pic }}" alt="Avatar" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 10px;">
         <span>{{ session.forum_user.username }}</span>
-        <button class="btn-chat btn btn-link p-0 mx-2"
-                data-chat-target="support"
-                title="Chat">
-            💬
-        </button>
+        {# Botón de chat removido #}
         <a href="{{ url_for('forum_auth.vforum_logout') }}" style="margin-left: 10px; color: var(--text-muted);">Salir</a>
     </div>
     {% endif %}

--- a/templates/forum_topic.html
+++ b/templates/forum_topic.html
@@ -106,11 +106,7 @@
     <div class="user-status" style="position: fixed; bottom: 20px; right: 20px; background: var(--bg-secondary); padding: 1rem; border-radius: 12px;">
         <img src="{{ session.forum_user.profile_pic }}" alt="Avatar" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 10px;">
         <span>{{ session.forum_user.username }}</span>
-        <button class="btn-chat btn btn-link p-0 mx-2"
-                data-chat-target="support"
-                title="Chat">
-            💬
-        </button>
+        {# Botón de chat removido #}
         <a href="{{ url_for('forum_auth.vforum_logout') }}" style="margin-left: 10px; color: var(--text-muted);">Salir</a>
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- drop floating chat code from base template
- comment out chat button in forum templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687d353b76cc83258c68e11dc3dc8fea