### PR TITLE
Implement user navigation panel

### DIFF
--- a/static/css/forum_custom.css
+++ b/static/css/forum_custom.css
@@ -1,0 +1,4 @@
+.unp-tab.active {
+  background-color: var(--primary);
+  color: #000;
+}

--- a/static/js/user_panel.js
+++ b/static/js/user_panel.js
@@ -1,0 +1,37 @@
+/* User Nav Panel EEVI */
+(() => {
+  const panel   = document.getElementById('user-nav-panel');
+  const fab     = document.getElementById('unp-fab');
+  const close   = document.getElementById('unp-close');
+  const tabs    = [...document.querySelectorAll('.unp-tab')];
+  const content = document.getElementById('unp-content');
+
+  const showPanel   = () => panel.classList.remove('hidden');
+  const hidePanel   = () => panel.classList.add('hidden');
+  const togglePanel = () => panel.classList.toggle('hidden');
+
+  fab  .addEventListener('click', togglePanel);
+  close.addEventListener('click', hidePanel);
+
+  /* Tabs */
+  tabs.forEach(btn => btn.addEventListener('click', () => {
+    tabs.forEach(t => t.classList.remove('active'));
+    btn.classList.add('active');
+    renderTab(btn.textContent.trim());
+  }));
+
+  function renderTab(name) {
+    if (name === 'Solicitudes') {
+      content.innerHTML = '<p class="text-xs text-gray-400">No hay solicitudes.</p>';
+    } else if (name === 'Amigos') {
+      content.innerHTML = '<p class="text-xs text-gray-400">Ningún amigo conectado.</p>';
+    } else { /* Mi Panel */
+      content.innerHTML = `
+        <p class="font-semibold text-primary">Hola, {{ session.get('user_name') or 'Invitado' }}!</p>
+        <p class="text-xs mt-1">Este es tu panel personal.</p>`;
+    }
+  }
+
+  /* Init */
+  renderTab('Solicitudes');
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/site.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/home_enhanced.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/forum_custom.css') }}">
 
   {% block head_admin %}{% endblock %}
   {% block extra_head %}{% endblock %}
@@ -44,5 +45,22 @@
         user_name: "{{ session.get('user_name', '') }}"
     };
   </script>
+  {% include 'forum/_user_panel.html' %}
+  <script src="{{ url_for('static', filename='js/user_panel.js') }}"></script>
+
+  <!-- Botón flotante -->
+  <button id="unp-fab"
+          class="fixed bottom-6 left-6 flex items-center gap-2 px-4 py-2
+                 bg-primary text-neutral-900 ring-2 ring-primary rounded-full
+                 shadow-lg z-40 hover:bg-gray-100 transition">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
+         viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M8 10h.01M12 10h.01M16 10h.01M8 14h.01M12 14h.01M16 14h.01
+               M21 12c0 4.418-4.03 8-9 8a9.77 9.77 0 01-4-.83L3 20l.92-3.684A7.964
+               7.964 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+    </svg>
+    <span class="text-sm font-semibold">Mi Panel</span>
+  </button>
 </body>
 </html>

--- a/templates/forum/_user_panel.html
+++ b/templates/forum/_user_panel.html
@@ -1,0 +1,26 @@
+<div id="user-nav-panel"
+     class="fixed bottom-6 right-6 w-72 bg-neutral-800 text-gray-100
+            ring-2 ring-primary rounded-xl shadow-xl z-40 hidden flex-col">
+
+  <!-- Cabecera -->
+  <div class="flex items-center justify-between px-4 py-2 bg-neutral-900 rounded-t-xl">
+    <span class="font-semibold text-sm">Panel de Usuario</span>
+    <button id="unp-close" class="hover:text-red-400">✖</button>
+  </div>
+
+  <!-- Tabs -->
+  <div class="flex gap-1 px-3 pt-2">
+    {% for tab in ['Solicitudes','Amigos','Mi Panel'] %}
+      <button class="unp-tab px-2 py-1 text-xs rounded
+                     hover:bg-primary/30 {% if loop.first %}active{% endif %}">
+        {{ tab }}
+      </button>
+    {% endfor %}
+  </div>
+
+  <!-- Contenidos -->
+  <div id="unp-content"
+       class="flex-1 overflow-y-auto p-3 space-y-2 text-sm">
+    <!-- placeholder; JS cargará solicitudes, amigos o tu mini-dashboard -->
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- create `_user_panel.html` with tabs for Solicitudes, Amigos and Mi Panel
- add new floating panel button and include user panel partial in `base.html`
- add JS logic for opening, closing and switching tabs
- include minimal CSS for active tab styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687d3bef81a08325954b8445e92dcfce