### PR TITLE
Remove footer quotes

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,14 +1,2 @@
-{% set quotes = [
-  "La cultura es tu caja de realidad...",
-  "Lo que llamamos realidad es un consenso de la comunidad...",
-  "La naturaleza ama el coraje..."] %}
 <footer class="text-center mt-16 py-8 opacity-80">
-  <em id="quote">{{ quotes|first }}</em>
 </footer>
-<script>
-  const frases={{ quotes|tojson }};
-  let qi=0; setInterval(()=>{ 
-     qi=(qi+1)%frases.length; 
-     document.getElementById('quote').textContent=frases[qi]; 
-  },15000);
-</script>


### PR DESCRIPTION
## Summary
- remove rotating quotes from site footer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687d4eb774d08325a5b662c08c49a67d