### PR TITLE
Add floating EEVI chat components

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>EEVI React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import { ChatModal, UserNavPanel } from './components/eeviChat';
+
+function App() {
+  const [isChatOpen, setIsChatOpen] = useState(false);
+
+  return (
+    <div className="App">
+      <h1>EEVI App</h1>
+      <UserNavPanel onOpenChat={() => setIsChatOpen(true)} />
+      <ChatModal isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/eeviChat/COLORS.js
+++ b/src/components/eeviChat/COLORS.js
@@ -1,0 +1,8 @@
+const COLORS = {
+  background: '#1A2332',
+  text: '#E9E9E9',
+  accent: '#00D4B8',
+  secondary: '#2A3441',
+  border: '#3A3F51'
+};
+export default COLORS;

--- a/src/components/eeviChat/ChatModal.jsx
+++ b/src/components/eeviChat/ChatModal.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { X, Send, MessageCircle, User, Clock, Minimize2, Maximize2 } from 'lucide-react';
+import COLORS from './COLORS';
+
+function ChatModal({ isOpen, onClose }) {
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const messagesEndRef = useRef(null);
+  const [minimized, setMinimized] = useState(false);
+
+  useEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, isOpen]);
+
+  function sendMessage() {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setMessages(m => [...m, { user: 'You', text: trimmed, time: new Date() }]);
+    setText('');
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '1rem',
+        right: '1rem',
+        width: '320px',
+        maxHeight: '70vh',
+        background: COLORS.background,
+        color: COLORS.text,
+        border: `1px solid ${COLORS.border}`,
+        borderRadius: '0.5rem',
+        boxShadow: '0 0 10px rgba(0,0,0,0.4)',
+        display: isOpen ? 'flex' : 'none',
+        flexDirection: 'column',
+        zIndex: 1000,
+      }}
+    >
+      <header
+        style={{
+          padding: '0.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          background: COLORS.secondary,
+          borderTopLeftRadius: '0.5rem',
+          borderTopRightRadius: '0.5rem',
+        }}
+      >
+        <span>Chat</span>
+        <div style={{ display: 'flex', gap: '0.25rem' }}>
+          <button
+            onClick={() => setMinimized(!minimized)}
+            style={{ background: 'transparent', border: 'none', color: COLORS.text }}
+          >
+            {minimized ? <Maximize2 size={16} /> : <Minimize2 size={16} />}
+          </button>
+          <button
+            aria-label="Cerrar"
+            onClick={onClose}
+            style={{ background: 'transparent', border: 'none', color: COLORS.text }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </header>
+      {!minimized && (
+        <>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '0.5rem' }}>
+            {messages.map((m, i) => (
+              <div key={i} style={{ marginBottom: '0.25rem' }}>
+                <span style={{ fontWeight: 'bold' }}>{m.user}:</span> {m.text}
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+          <footer style={{ borderTop: `1px solid ${COLORS.border}`, padding: '0.5rem', display: 'flex', gap: '0.25rem' }}>
+            <textarea
+              rows={1}
+              value={text}
+              onChange={e => setText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Escribe... Ctrl+Enter"
+              style={{ flex: 1, resize: 'none', background: 'transparent', color: COLORS.text, border: `1px solid ${COLORS.border}`, borderRadius: '0.25rem', padding: '0.25rem' }}
+            />
+            <button
+              aria-label="Enviar"
+              onClick={sendMessage}
+              style={{ background: COLORS.accent, border: 'none', color: COLORS.background, padding: '0.25rem 0.5rem', borderRadius: '0.25rem' }}
+            >
+              <Send size={16} />
+            </button>
+          </footer>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ChatModal;

--- a/src/components/eeviChat/UserNavPanel.jsx
+++ b/src/components/eeviChat/UserNavPanel.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { MessageCircle, User } from 'lucide-react';
+import COLORS from './COLORS';
+
+function UserNavPanel({ onOpenChat }) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '5rem',
+        right: '1rem',
+        display: open ? 'flex' : 'none',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        zIndex: 999,
+      }}
+    >
+      <button
+        onClick={onOpenChat}
+        style={{ background: COLORS.accent, border: 'none', color: COLORS.background, borderRadius: '50%', width: '40px', height: '40px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        aria-label="Abrir chat"
+      >
+        <MessageCircle size={20} />
+      </button>
+      <button
+        style={{ background: COLORS.secondary, border: 'none', color: COLORS.text, borderRadius: '50%', width: '40px', height: '40px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        aria-label="Usuario"
+      >
+        <User size={20} />
+      </button>
+    </div>
+  );
+}
+
+export default UserNavPanel;

--- a/src/components/eeviChat/index.js
+++ b/src/components/eeviChat/index.js
@@ -1,0 +1,2 @@
+export { default as ChatModal } from './ChatModal';
+export { default as UserNavPanel } from './UserNavPanel';

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add generic ChatModal and UserNavPanel components
- expose components via src/components/eeviChat index
- create COLORS palette helper
- add App that mounts chat components
- provide basic index.html and entry point

## Testing
- `npm run dev` *(fails: Missing script "dev")*

------
https://chatgpt.com/codex/tasks/task_e_687d5217548c8325901a1b887c889817