### PR TITLE
Add socket.io chat server and client updates

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_CHAT_URL=http://localhost:4000

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.0",
   "dependencies": {
     "lucide-react": "^0.300.0",
-    "socket.io-client": "^4.7.5"
+    "socket.io-client": "^4.7.5",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5",
+    "cors": "^2.8.5"
   },
   "scripts": {
-    "postinstall": "npx tailwindcss init -p || true"
+    "postinstall": "npx tailwindcss init -p || true",
+    "chat-server": "node server/chatServer.js"
   }
 }

--- a/server/chatServer.js
+++ b/server/chatServer.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import http from 'http';
+import { Server } from 'socket.io';
+import cors from 'cors';
+
+const app = express();
+app.use(cors({ origin: '*' }));
+
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: { origin: '*' }
+});
+
+io.on('connection', (socket) => {
+  console.log('\ud83d\dd0c Usuario conectado', socket.id);
+
+  socket.on('chat message', (msg) => {
+    io.emit('chat message', msg);
+  });
+
+  socket.on('disconnect', () => {
+    console.log('\u26d4 Usuario desconectado', socket.id);
+  });
+});
+
+const PORT = process.env.PORT || 4000;
+server.listen(PORT, () => {
+  console.log(`\ud83d\dfE Chat server escuchando en http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement chat server using express and socket.io
- update ChatModal to use socket.io client for real-time messages
- expose chat server url via `.env`
- include server script in `package.json`

## Testing
- `npm run chat-server` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_687d541b6a208325a26895704176ee2b