### PR TITLE
Serve React build from chat server

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "autoprefixer": "^10.4.16"
   },
   "scripts": {
-    "postinstall": "npx tailwindcss init -p || true",
-    "chat-server": "node server/chatServer.js"
+    "dev": "vite",
+    "build": "vite build",
+    "chat-server": "node server/chatServer.js",
+    "start": "node server/chatServer.js",
+    "postinstall": "npx tailwindcss init -p || true"
   }
 }

--- a/server/chatServer.js
+++ b/server/chatServer.js
@@ -2,9 +2,22 @@ import express from 'express';
 import http from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(cors({ origin: '*' }));
+
+// Servir archivos estáticos del build React
+const distPath = path.join(__dirname, '..', 'dist');
+app.use(express.static(distPath));
+
+// Catch-all: devuelve index.html para rutas de SPA
+app.get('*', (req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
 
 const server = http.createServer(app);
 const io = new Server(server, {


### PR DESCRIPTION
## Summary
- update Node server to serve the React SPA
- add Vite build/start scripts to package.json

## Testing
- `pytest -q` *(fails: pyenv version `3.11.9` is not installed)*
- `npm install -D vite @vitejs/plugin-react` *(fails: 403 Forbidden - registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d5af0ea3c8325ad49475577df5a71