### PR TITLE
Fix Vite config for Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
   "devDependencies": {
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
+    "vite": "^5.3.0",
+    "@vitejs/plugin-react": "^4.2.0"
   },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "preview": "vite preview",
     "chat-server": "node server/chatServer.js",
     "start": "node server/chatServer.js",
     "postinstall": "npx tailwindcss init -p || true"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+  },
+});


### PR DESCRIPTION
## Summary
- install vite and the React plugin
- add preview script
- include vite config file

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.9` is not installed)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687d5cf2a1d48325baafa81088e6b10c