### PR TITLE
Add react 18 deps and adjust main.jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "dependencies": {
     "lucide-react": "^0.300.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "socket.io-client": "^4.7.5",
     "express": "^4.19.2",
     "socket.io": "^4.7.5",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- add React 18 and react-dom 18 dependencies
- use `createRoot` import in `src/main.jsx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687d5f3e681c8325b2c06124e4ef15bf