### PR TITLE
Add Home page with forum markup and integrate chat

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,17 @@
 import React, { useState } from 'react';
+import Home from './pages/Home.jsx';
 import { ChatModal, UserNavPanel } from './components/eeviChat';
 
-function App() {
+export default function App() {
   const [isChatOpen, setIsChatOpen] = useState(false);
 
   return (
-    <div className="App">
-      <h1>EEVI App</h1>
+    <>
+      <Home />
+
+      {/* flotantes, sin tocar */}
       <UserNavPanel onOpenChat={() => setIsChatOpen(true)} />
       <ChatModal isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
-    </div>
+    </>
   );
 }
-
-export default App;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+export default function Home() {
+  return (
+    <main className="p-6">
+      {/*  \u2B07\uFE0F  pega aquí el markup original del foro  \u2B07\uFE0F */}
+      <h1 className="vforum-title">VFORUM</h1>
+      <section className="quote-slider">
+        <div className="quote-slide">"Inspiración para creadores"</div>
+        <div className="quote-slide">"Comparte y aprende"</div>
+      </section>
+      <div className="sticky-new-topic top">
+        <a href="#" className="btn-new-topic">+ Nuevo Tema</a>
+      </div>
+      <div className="topic-list">
+        <div className="topic-card">
+          <h3><a href="#">Tema de ejemplo</a></h3>
+          <p className="topic-meta">Categoría • Fecha • Autor</p>
+          <p>Descripción del tema...</p>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Home page with forum markup as React component
- update App.jsx to render Home alongside floating chat

## Testing
- `npm run dev` *(fails: `npm` not found)*
- `npm run build` *(not executed due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_687d63798d688325824b10ff7d2a9d5f