### PR TITLE
Restore Python backend templates and integrate chat widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "scripts": {
     "build": "vite build",
-    "start": "node server/chatServer.js"
+    "chat-server": "node server/chatServer.js"
   }
 }

--- a/server/chatServer.js
+++ b/server/chatServer.js
@@ -2,22 +2,10 @@ import express from 'express';
 import http from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
-import path from 'path';
-import { fileURLToPath } from 'url';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(cors({ origin: '*' }));
 
-// ruta estática para el widget compilado
-const distPath = path.join(__dirname, '..', 'dist');
-app.use(express.static(distPath));
-
-// Home del foro
-app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'templates', 'home_enhanced.html'));
-});
 
 const server = http.createServer(app);
 const io = new Server(server, {

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,6 +45,9 @@
         user_name: "{{ session.get('user_name', '') }}"
     };
   </script>
-  {# Chat UI removed #}
+  <div id="eevi-chat-root"></div>
+  {% if not config['DEBUG'] %}
+  <script src="{{ url_for('static', filename='chat-widget.js') }}" defer></script>
+  {% endif %}
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -986,5 +986,7 @@
         }
 
     </script>
+    <div id="eevi-chat-root"></div>
+    <script src="/static/chat-widget.js" defer></script>
 </body>
 </html>

--- a/templates/home_enhanced.html
+++ b/templates/home_enhanced.html
@@ -185,7 +185,4 @@ function handleCommunityClick() {
   {{ super() }}
   <!-- Script propio -->
   <script src="{{ url_for('static', filename='js/home_enhanced.js') }}"></script>
-  <!-- EEVI chat mount -->
-  <div id="eevi-chat-root"></div>
-  <script src="/chat-widget.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove Express routes and static serving from `chatServer.js`
- expose chat widget on every page via `base.html`
- add chat widget reference for `home.html`
- clean up `home_enhanced.html` and update scripts
- rename npm start script to `chat-server`

## Testing
- `npm run build` *(fails: `vite` not found)*
- `pytest -q` *(fails: pyenv couldn't find Python 3.11.9)*

------
https://chatgpt.com/codex/tasks/task_e_687d6c1040448325ae63d5de3df713ce