### PR TITLE
Add chat bubble and Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,45 +1,27 @@
 # === render.yaml ===
 services:
-  # ─────────────────────────────────────────────────────────────
-  #  API + SPA  (Python runtime → gunicorn + Vite build output)
-  # ─────────────────────────────────────────────────────────────
   - name: eevi-api
     type: web
-    runtime: python           # fuerza contenedor Python ⇒ pip disponible
-    plan: free                # cámbialo si necesitas más recursos
-
-    # 1️⃣  Instala dependencias Python (incluye gunicorn)
-    # 2️⃣  Instala dependencias Node y compila frontend con Vite
-    # 3️⃣  Copia todo el bundle de dist/ a static/ para que Flask lo sirva
+    runtime: python
+    plan: free
     buildCommand: |
       pip install --no-cache-dir -r requirements.txt
-      npm ci
-      npm run build                     # genera dist/
+      npm install --legacy-peer-deps
+      npm run build
       mkdir -p static
       cp -r dist/* static/
-
-    # Inicia gunicorn con 3 workers gevent (ajusta si hace falta)
     startCommand: gunicorn -k gevent -w 3 app:app
-
     envVars:
-      # JSON de credenciales Firestore (todo en **una** línea sin saltos)
       - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
         value: "PASTE_YOUR_COMPACT_JSON_HERE"
-      # URL pública del servicio Node que corre socket.io
       - key: VITE_CHAT_URL
         value: "https://eevi-chat.onrender.com"
 
-  # ─────────────────────────────────────────────────────────────
-  #  Servicio tiempo‑real de chat  (Node runtime → socket.io)
-  # ─────────────────────────────────────────────────────────────
   - name: eevi-chat
     type: web
     runtime: node
     plan: free
-
     buildCommand: |
-      npm ci
-
+      npm install
     startCommand: node server/chatServer.js
-
-    envVars: []   # agrega aquí envs que necesite tu chat‑server
+    envVars: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-Flask>=3.0
+Flask
 gunicorn
 google-cloud-firestore
-google-auth
-flask-login

--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -1,0 +1,22 @@
+import { MessageCircle } from 'lucide-react';
+import type { FC } from 'react';
+
+interface ChatBubbleProps {
+  onClick: () => void;
+  visible: boolean;
+}
+
+const ChatBubble: FC<ChatBubbleProps> = ({ onClick, visible }) => {
+  if (!visible) return null;
+  return (
+    <button
+      aria-label="Abrir chat"
+      onClick={onClick}
+      className="fixed bottom-4 left-4 w-12 h-12 rounded-full bg-blue-600 text-white flex items-center justify-center shadow fade-in"
+    >
+      <MessageCircle size={24} />
+    </button>
+  );
+};
+
+export default ChatBubble;

--- a/src/components/chat/eevi-chat-modal.tsx
+++ b/src/components/chat/eevi-chat-modal.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState, type FC } from 'react';
+import { X, Send, Minimize2, Maximize2 } from 'lucide-react';
+import { io, Socket } from 'socket.io-client';
+
+interface ChatMessage {
+  id: number;
+  text: string;
+  sender?: string;
+}
+
+interface ChatModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const socket: Socket = io(import.meta.env.VITE_CHAT_URL ?? 'http://localhost:4000');
+
+const EeviChatModal: FC<ChatModalProps> = ({ open, onClose }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [text, setText] = useState('');
+  const [minimized, setMinimized] = useState(false);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    socket.on('chat message', (msg: ChatMessage) => {
+      setMessages(prev => [...prev, msg]);
+    });
+    return () => {
+      socket.off('chat message');
+    };
+  }, []);
+
+  useEffect(() => {
+    if (endRef.current) endRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, open]);
+
+  function send() {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const msg: ChatMessage = { id: Date.now(), text: trimmed, sender: 'User' };
+    setMessages(prev => [...prev, msg]);
+    socket.emit('chat message', msg);
+    setText('');
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 w-80 max-h-[70vh] bg-white text-black border border-gray-300 rounded shadow flex flex-col z-50 fade-in">
+      <header className="p-2 flex items-center justify-between bg-gray-100 rounded-t">
+        <span>Chat</span>
+        <div className="flex gap-1">
+          <button onClick={() => setMinimized(!minimized)} aria-label="Minimizar" className="text-gray-600">
+            {minimized ? <Maximize2 size={16} /> : <Minimize2 size={16} />}
+          </button>
+          <button onClick={onClose} aria-label="Cerrar" className="text-gray-600">
+            <X size={16} />
+          </button>
+        </div>
+      </header>
+      {!minimized && (
+        <>
+          <div className="flex-1 overflow-y-auto p-2">
+            {messages.map(m => (
+              <div key={m.id} className="mb-1">
+                <span className="font-bold">{m.sender ?? 'Anon'}:</span> {m.text}
+              </div>
+            ))}
+            <div ref={endRef} />
+          </div>
+          <footer className="border-t border-gray-300 p-2 flex gap-1">
+            <textarea
+              className="flex-1 resize-none border border-gray-300 rounded p-1 bg-transparent"
+              rows={1}
+              value={text}
+              onChange={e => setText(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                  e.preventDefault();
+                  send();
+                }
+              }}
+              placeholder="Escribe... Ctrl+Enter"
+            />
+            <button onClick={send} aria-label="Enviar" className="bg-blue-600 text-white rounded px-2">
+              <Send size={16} />
+            </button>
+          </footer>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default EeviChatModal;

--- a/src/components/panels/UserBellPanel.tsx
+++ b/src/components/panels/UserBellPanel.tsx
@@ -1,0 +1,17 @@
+import { User } from 'lucide-react';
+import type { FC } from 'react';
+
+const UserBellPanel: FC = () => {
+  return (
+    <div className="fixed bottom-24 right-4 flex flex-col gap-2 z-40">
+      <button
+        className="w-10 h-10 rounded-full bg-gray-800 text-white flex items-center justify-center shadow"
+        aria-label="Usuario"
+      >
+        <User size={20} />
+      </button>
+    </div>
+  );
+};
+
+export default UserBellPanel;

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.fade-in { animation: fade-in 0.3s ease-in-out; }
+.fade-out { animation: fade-out 0.3s ease-in-out; }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import './global.css';
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/pages/ForoPage.tsx
+++ b/src/pages/ForoPage.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import EeviChatModal from '../components/chat/eevi-chat-modal';
+import ChatBubble from '../components/chat/ChatBubble';
+import UserBellPanel from '../components/panels/UserBellPanel';
+
+const ForoPage = () => {
+  const [chatOpen, setChatOpen] = useState(false);
+  return (
+    <>
+      <UserBellPanel />
+      <ChatBubble onClick={() => setChatOpen(true)} visible={!chatOpen} />
+      <EeviChatModal open={chatOpen} onClose={() => setChatOpen(false)} />
+    </>
+  );
+};
+
+export default ForoPage;


### PR DESCRIPTION
## Summary
- simplify requirements.txt
- update render.yaml for python and node services
- import global styles in React
- add TS chat bubble and chat modal
- create floating user panel
- add Foro page
- define fade animations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687e733accf08325a6cf83ef925485d9