### PR TITLE
Fix community link redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,20 @@ legacy = Blueprint("client", __name__)
 def home_redirect():
     return redirect(url_for("home"))
 
+# --- Compatibilidad para la plantilla base (COMUNIDAD) ----------------------
+from flask import Blueprint, redirect, url_for
+
+forum_auth = Blueprint("forum_auth", __name__)
+
+@forum_auth.route("/forum", endpoint="vforum_auth")
+def forum_redirect():
+    # Redirige a la SPA manteniendo ruta /forum
+    return redirect(url_for("spa_routes", sub="forum"))
+
+# Registrar el alias
+app.register_blueprint(forum_auth, url_prefix="")
+# ---------------------------------------------------------------------------
+
 app.register_blueprint(legacy, url_prefix="")
 app.register_blueprint(chat_bp, url_prefix="/chat")
 


### PR DESCRIPTION
## Summary
- add small alias blueprint to redirect `/forum` to SPA

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687e7ad06c9083258fc2add27db2219e