### PR TITLE
Fix list_forum endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,13 @@ def forum_alias():
 app.register_blueprint(forum_auth, url_prefix="")
 # -----------------------------------------------------------------------------
 
+# --- Alias para BUSCAR PROYECTO --------------------------------------------
+@app.route("/projects", endpoint="list_forum")
+def list_forum():
+    # Reutiliza la misma SPA
+    return render_template("home_enhanced.html")
+# ---------------------------------------------------------------------------
+
 
 @app.route("/", methods=["GET", "HEAD"])
 def home():


### PR DESCRIPTION
## Summary
- add `list_forum` route alias for `/projects`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687e887640788325bdd838a6ad52d14c