### PR TITLE
Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 Flask
+Flask-SQLAlchemy
+Flask-Migrate
 gunicorn
 google-cloud-firestore
+Werkzeug


### PR DESCRIPTION
## Summary
- include Flask-Migrate and Flask-SQLAlchemy
- include Werkzeug

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687e905019e083258deeae4bf1d43b35