### PR TITLE
Fix home_enhanced URL endpoints

### DIFF
--- a/templates/home_enhanced.html
+++ b/templates/home_enhanced.html
@@ -171,10 +171,10 @@
 function handleCommunityClick() {
     {% if current_user and current_user.is_authenticated %}
         // Usuario autenticado - ir al foro
-        window.location.href = "{{ url_for('forum.index') if url_for else '/forum' }}";
+        window.location.href = "{{ url_for('list_forum') if url_for else '/forum' }}";
     {% else %}
         // Usuario no autenticado - ir a registro/login
-        window.location.href = "{{ url_for('auth.register') if url_for else '/forum#register' }}";
+        window.location.href = "{{ url_for('forum_auth.register_user') if url_for else '/forum#register' }}";
     {% endif %}
 }
 </script>


### PR DESCRIPTION
## Summary
- fix forum redirect in JS to use `list_forum`
- fix registration redirect to use `forum_auth.register_user`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -q -r requirements.txt` *(failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687e92926ee0832595f571713e138d9a