### PR TITLE
Fix forum_auth registration and add register page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 from flask import Flask, render_template, Blueprint, redirect, url_for
 from routes.chat import chat_bp   # <- conserva tu blueprint de chat
 from routes.packs import packs_bp
+from routes.forum_auth import forum_auth
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
 
@@ -18,16 +19,9 @@ def client_home():
 app.register_blueprint(client, url_prefix="")   # sin prefijo
 
 # ╭─────────────────────────────────────────────────────────────╮
-# │ 2.  ALIAS 'forum_auth' → cubre url_for('forum_auth.vforum_auth') │
+# │ 2.  Blueprint de autenticación del foro                     │
 # ╰─────────────────────────────────────────────────────────────╯
-forum_auth = Blueprint("forum_auth", __name__)
-
-@forum_auth.route("/forum", endpoint="vforum_auth")
-def forum_alias():
-    # Sirve directamente la SPA para /forum
-    return render_template("home_enhanced.html")
-
-app.register_blueprint(forum_auth, url_prefix="")
+app.register_blueprint(forum_auth)
 
 # ╭─────────────────────────────────────────────────────────────╮
 # │ 3.  ALIAS list_forum  → cubre url_for('list_forum')         │

--- a/routes/forum_auth.py
+++ b/routes/forum_auth.py
@@ -6,7 +6,9 @@ from services.fs_client import fs_client
 from datetime import datetime, timedelta
 import re
 
-forum_auth_bp = Blueprint('forum_auth', __name__, template_folder='templates')
+# Blueprint principal del foro. Se registra como 'forum_auth'
+forum_auth = Blueprint('forum_auth', __name__, url_prefix='/forum',
+                       template_folder='templates')
 
 # Frases rotativas para usuarios existentes
 LOGIN_PHRASES = [
@@ -19,7 +21,7 @@ LOGIN_PHRASES = [
     "Ingresar a mi cuenta"
 ]
 
-@forum_auth_bp.route('/')
+@forum_auth.route('/')
 def vforum_auth():
     """Vista unificada de registro/login"""
     if session.get('forum_user'):
@@ -37,7 +39,7 @@ def vforum_auth():
                          professions=professions,
                          login_phrases=LOGIN_PHRASES)
 
-@forum_auth_bp.route('/register', methods=['POST'], endpoint='register_user')
+@forum_auth.route('/register', methods=['POST'], endpoint='register_user')
 def register_user():
     """Registro básico para VFORUM."""
     data = request.get_json() or {}
@@ -71,7 +73,7 @@ def register_user():
 
     return jsonify({'success': True})
 
-@forum_auth_bp.route('/login', methods=['POST'])
+@forum_auth.route('/login', methods=['POST'])
 def vforum_login():
     """Login de usuario existente"""
     from app import usuarios_ref
@@ -118,7 +120,7 @@ def vforum_login():
 
     return jsonify({'success': True, 'redirect': url_for('list_forum')})
 
-@forum_auth_bp.route('/logout')
+@forum_auth.route('/logout')
 def vforum_logout():
     """Cerrar sesión"""
     if 'forum_user' in session:
@@ -133,7 +135,7 @@ def vforum_logout():
 
 
 # Alias legacy para mantener compatibilidad con templates antiguos
-@forum_auth_bp.route('/list', endpoint='list_forum')
+@forum_auth.route('/list', endpoint='list_forum')
 def list_forum():
     """Redirige al inicio del foro."""
     from flask import redirect, url_for

--- a/templates/register_user.html
+++ b/templates/register_user.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Registro de usuario</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- register the forum_auth blueprint so `url_for('forum_auth.register_user')` works
- rename blueprint variable inside `routes/forum_auth.py`
- add placeholder template for user registration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687e9d4076cc83259fbbe1ca1c156c47