### PR TITLE
Add forum chat overlay

### DIFF
--- a/src/pages/ForoPage.tsx
+++ b/src/pages/ForoPage.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
-import ForumChatOverlay from '../components/forumChat/ForumChatOverlay';
+import ForumChatOverlay from '@/components/forumChat/ForumChatOverlay';
 
-const ForoPage = () => {
-  return (
-    <div>
-      {/* ...tu contenido de foro... */}
-      <ForumChatOverlay user={{ username: 'UsuarioEEVI_2025' }} />
-    </div>
-  );
+const mockUser = {
+  username: 'UsuarioEEVI_2025',
 };
+export default function ForoPage() {
+  return (
+    <main className="relative min-h-screen bg-[#0A0A0A] text-white">
+      <section className="py-8 px-4">
+        <h1 className="text-3xl font-bold mb-4">Bienvenido al Foro</h1>
+        {/* Otros componentes del foro van aquí */}
+      </section>
 
-export default ForoPage;
+      {/* Chat overlay global */}
+      <ForumChatOverlay user={mockUser} />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- embed `ForumChatOverlay` on Foro page as a global floating overlay

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687efa1a04348325a7b67734b6d01c35