### PR TITLE
Fix DB init with get_bind removal

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+# Se reemplaza inicialización de DB para evitar get_bind error en Render
 from flask import Flask, flash, redirect
 from flask_sqlalchemy import SQLAlchemy
 from flask_appbuilder import AppBuilder, Model
@@ -22,21 +23,18 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 # Auto‐crear tablas y usuario admin sin consola
 with app.app_context():
-    try:
-        db.create_all()
-        from flask_appbuilder.security.sqla.models import User
-        sm = appbuilder.sm
-        if not User.query.filter_by(username='admin').first():
-            sm.add_user(
-                username='admin',
-                first_name='Administrador',
-                last_name='EEVI',
-                email='admin@eevi.cl',
-                role=sm.find_role('Admin'),
-                password='admin123'
-            )
-    except Exception as e:
-        print("DB Creation and initialization failed:", e)
+    db.create_all()
+    from flask_appbuilder.security.sqla.models import User
+    sm = appbuilder.sm
+    if not User.query.filter_by(username='admin').first():
+        sm.add_user(
+            username='admin',
+            first_name='Administrador',
+            last_name='EEVI',
+            email='admin@eevi.cl',
+            role=sm.find_role('Admin'),
+            password='admin123'
+        )
 
 # Modelo
 class Recurso(Model):


### PR DESCRIPTION
## Summary
- refresh DB initialization with SQLAlchemy
- auto-create Admin user on startup

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687f0382c9e08325844521b2555a8a9f