### PR TITLE
Fix SQLAlchemy config

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,16 +1,16 @@
 from flask import Flask, flash, redirect
 from flask_sqlalchemy import SQLAlchemy
 
-from sqlalchemy import Column, Integer, String, or_
+from sqlalchemy import Column, Integer, String
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SECRET_KEY'] = 'supersecretkey'
 app.config['CSRF_ENABLED'] = True
 
 # Base de datos
 db = SQLAlchemy(app)
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 # Crea las tablas automaticamente
 with app.app_context():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.3
 Flask-SQLAlchemy<3.0
+SQLAlchemy<2.0
 gunicorn


### PR DESCRIPTION
## Summary
- pin SQLAlchemy versions for compatibility
- configure SQLAlchemy before initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687f0c45cc288325b9b79ebb4cdf0ce9