### PR TITLE
Add standalone React chat widget

### DIFF
--- a/static/chat-widget/index.html
+++ b/static/chat-widget/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>EEVI Chat Widget</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+  <div id="eevi-chat-root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/static/chat-widget/package.json
+++ b/static/chat-widget/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "eevi-chat-widget",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "lucide-react": "^0.255.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/static/chat-widget/src/COLORS.ts
+++ b/static/chat-widget/src/COLORS.ts
@@ -1,0 +1,7 @@
+export default {
+  background: '#1A2332',
+  text: '#E9E9E9',
+  accent: '#00D4B8',
+  secondary: '#2A3441',
+  border: '#3A3F51'
+};

--- a/static/chat-widget/src/components/ChatModal.tsx
+++ b/static/chat-widget/src/components/ChatModal.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect, useRef } from 'react';
+import COLORS from '../COLORS';
+
+interface ChatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ChatModal({ isOpen, onClose }: ChatModalProps) {
+  const [chatId, setChatId] = useState<string | null>(null);
+  const [title, setTitle] = useState('Chat');
+  const [messages, setMessages] = useState<any[]>([]);
+  const [text, setText] = useState('');
+  const msgEnd = useRef<HTMLDivElement>(null);
+  const pollRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    if (isOpen && chatId) {
+      loadMessages();
+      pollRef.current = setInterval(loadMessages, 4000);
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [isOpen, chatId]);
+
+  useEffect(() => {
+    if (msgEnd.current) msgEnd.current.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    function handler(e: any) {
+      setTitle(e.detail.name || 'Chat');
+      setChatId(e.detail.chatId);
+    }
+    window.addEventListener('openChat', handler);
+    return () => window.removeEventListener('openChat', handler);
+  }, []);
+
+  async function loadMessages() {
+    try {
+      const res = await fetch(`/chat/get_messages/${chatId}`);
+      const data = await res.json();
+      if (data.success) setMessages(data.messages);
+    } catch (e) {
+      console.error('loadMessages', e);
+    }
+  }
+
+  async function send() {
+    const mensaje = text.trim();
+    if (!mensaje) return;
+    try {
+      await fetch('/chat/send_message', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, mensaje })
+      });
+      setText('');
+      await loadMessages();
+    } catch (e) {
+      console.error('send', e);
+    }
+  }
+
+  function handleKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      send();
+    }
+  }
+
+  if (!isOpen) return null;
+
+  const containerStyle: React.CSSProperties = {
+    position: 'fixed',
+    bottom: 80,
+    right: 24,
+    width: 320,
+    maxHeight: '70vh',
+    background: COLORS.secondary,
+    color: COLORS.text,
+    borderRadius: 12,
+    boxShadow: '0 2px 10px rgba(0,0,0,0.5)',
+    display: 'flex',
+    flexDirection: 'column',
+    zIndex: 1000
+  };
+
+  return (
+    <div style={containerStyle}>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          background: COLORS.background,
+          padding: '8px 12px',
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12
+        }}
+      >
+        <h3
+          style={{
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {title}
+        </h3>
+        <button
+          aria-label="Cerrar chat"
+          onClick={onClose}
+          style={{ color: COLORS.text }}
+        >
+          ✖
+        </button>
+      </header>
+      <section
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: '8px 12px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px'
+        }}
+      >
+        {messages.map((m, i) => {
+          const own =
+            (window as any).currentUser &&
+            m.autor_id === (window as any).currentUser.user_id;
+          const base: React.CSSProperties = {
+            display: 'inline-block',
+            maxWidth: '70%',
+            padding: '4px 8px',
+            borderRadius: 8,
+            wordBreak: 'break-word'
+          };
+          const bubbleStyle: React.CSSProperties = own
+            ? {
+                ...base,
+                alignSelf: 'flex-end',
+                background: COLORS.accent,
+                color: '#fff',
+                borderBottomRightRadius: 0
+              }
+            : {
+                ...base,
+                alignSelf: 'flex-start',
+                background: '#3b3b3b',
+                borderBottomLeftRadius: 0
+              };
+          return (
+            <div
+              key={i}
+              style={{ display: 'flex', justifyContent: own ? 'flex-end' : 'flex-start' }}
+            >
+              <span style={bubbleStyle}>
+                <span style={{ fontWeight: 600 }}>{m.autor_nombre}:</span> {m.mensaje}
+              </span>
+            </div>
+          );
+        })}
+        <div ref={msgEnd}></div>
+      </section>
+      <footer
+        style={{
+          borderTop: `1px solid ${COLORS.border}`,
+          padding: 8,
+          display: 'flex',
+          alignItems: 'flex-end',
+          gap: 4
+        }}
+      >
+        <textarea
+          rows={1}
+          placeholder="Escribe… Ctrl+Enter"
+          style={{
+            flex: 1,
+            background: 'transparent',
+            resize: 'none',
+            outline: 'none',
+            color: COLORS.text
+          }}
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onKeyDown={handleKey}
+        />
+        <button aria-label="Enviar" style={{ padding: '0 8px' }} onClick={send}>
+          ➤
+        </button>
+      </footer>
+    </div>
+  );
+}
+
+export function openChatWith(userId: string, name: string) {
+  const event = new CustomEvent('openChat', { detail: { chatId: userId, name } });
+  window.dispatchEvent(event);
+}

--- a/static/chat-widget/src/components/ChatOverlay.tsx
+++ b/static/chat-widget/src/components/ChatOverlay.tsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+import UserNavPanel from './UserNavPanel';
+import ChatModal from './ChatModal';  // adapta tu eevi-chat-modal.tsx aquí
+
+export default function ChatOverlay() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <UserNavPanel onOpen={() => setOpen(true)} />
+      <ChatModal isOpen={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/static/chat-widget/src/components/UserNavPanel.tsx
+++ b/static/chat-widget/src/components/UserNavPanel.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { User, MessageCircle } from 'lucide-react';
+import COLORS from '../COLORS';
+
+export default function UserNavPanel({ onOpen }) {
+  return (
+    <button
+      onClick={onOpen}
+      style={{
+        position: 'fixed',
+        top: 16,
+        right: 16,
+        background: COLORS.secondary,
+        border: `2px solid ${COLORS.border}`,
+        borderRadius: 8,
+        padding: '8px 12px',
+        color: COLORS.text,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        zIndex: 1000,
+        cursor: 'pointer'
+      }}
+    >
+      <User size={16} /> <MessageCircle size={16} />
+    </button>
+  );
+}

--- a/static/chat-widget/src/main.tsx
+++ b/static/chat-widget/src/main.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import ChatOverlay from './components/ChatOverlay';
+
+const container = document.getElementById('eevi-chat-root');
+if (container) createRoot(container).render(<ChatOverlay />);

--- a/static/chat-widget/tsconfig.json
+++ b/static/chat-widget/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/static/chat-widget/vite.config.ts
+++ b/static/chat-widget/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/main.tsx',
+      formats: ['esm']
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold `eevi-chat-widget` React overlay under `static/chat-widget`
- include Vite config, TS config and colours
- implement simple chat modal with user panel

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687ff713afac832584961821a67158bf