### PR TITLE
Enable Socket.IO chat backend

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --log-level warning
+web: gunicorn --worker-class eventlet -w 1 app:socketio --log-level warning

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: eevi-verite
     runtime: python
-    startCommand: "gunicorn app:app"
+    startCommand: "gunicorn --worker-class eventlet -w 1 app:socketio"
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ SQLAlchemy>=2.0
 psycopg2-binary>=2.9
 gunicorn==22.0.0
 Werkzeug>=3.0
+Flask-SocketIO>=5.3
+eventlet>=0.33
 
 Flask-Migrate==4.0.5
 Alembic>=1.13

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,12 @@
 
   {% block head_admin %}{% endblock %}
   {% block extra_head %}{% endblock %}
+  <script>
+    window.currentUser = {
+      id: "{{ session.forum_user.id if session.forum_user else '' }}",
+      username: "{{ session.forum_user.username if session.forum_user else 'Guest' }}"
+    };
+  </script>
 </head>
 <body>
   <header class="header-unified">
@@ -38,13 +44,7 @@
   <script src="{{ url_for('static', filename='js/mobile_stability.js') }}"></script>
   {% endblock %}
   <script src="{{ url_for('static', filename='js/nav_unified.js') }}"></script>
-  <script>
-    window.currentUser = {
-        authenticated: {% if session.get('user_id') %}true{% else %}false{% endif %},
-        user_id: "{{ session.get('user_id', '') }}",
-        user_name: "{{ session.get('user_name', '') }}"
-    };
-  </script>
-  {# Chat UI removed #}
+  <div id="eevi-chat-root"></div>
+  <script type="module" src="{{ url_for('static', filename='chat-widget/dist/index.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Flask-SocketIO for websocket chat
- expose `currentUser` to widget and mount chat widget
- run with eventlet workers on Render

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68801147a45083259447607d7aa7cb6b