### PR TITLE
Add process polyfill and build configuration

### DIFF
--- a/static/chat-widget/package.json
+++ b/static/chat-widget/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "esbuild src/ChatModal.tsx --bundle --outfile=dist/index.js --format=esm --minify"
+    "build": "esbuild src/ChatModal.tsx --bundle --outfile=dist/index.js --format=esm --minify --define:process.env.NODE_ENV=\\\"production\\\""
   },
   "dependencies": {
     "react": "^18.0.0",

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,6 +45,10 @@
   {% endblock %}
   <script src="{{ url_for('static', filename='js/nav_unified.js') }}"></script>
   <div id="eevi-chat-root"></div>
+  <script>
+    // Polyfill global de process para evitar 'ReferenceError: process is not defined'
+    window.process = { env: { NODE_ENV: 'production' } };
+  </script>
   <script type="module" src="{{ url_for('static', filename='chat-widget/dist/index.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- insert a window.process polyfill in `base.html`
- update chat widget build script to define `process.env.NODE_ENV`

## Testing
- `npm ci` *(fails: no package-lock)*
- `npm run build` *(fails: esbuild not found)*
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_688032efbb208325bcf84d305ba8b278