### PR TITLE
Implement basic global chat

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from routes.client import client_bp
 from routes.auth import auth_bp
 from routes.projects import projects_bp
 from routes.messages import messages_bp
+from routes.chat_api import chat_api_bp
 
 # Nuevos blueprints
 try:
@@ -83,7 +84,8 @@ app.register_blueprint(client_bp)
 app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(projects_bp, url_prefix='/projects')
 app.register_blueprint(messages_bp, url_prefix='/messages')
-app.register_blueprint(chat_bp, url_prefix='/chat') 
+app.register_blueprint(chat_bp, url_prefix='/chat')
+app.register_blueprint(chat_api_bp)
 
 if FRIENDS_AVAILABLE:
     app.register_blueprint(friends_bp, url_prefix='/friends')

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -83,3 +83,10 @@ CREATE TABLE IF NOT EXISTS packs (
     price TEXT,
     image_url TEXT
 );
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user TEXT NOT NULL,
+    text TEXT NOT NULL,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/routes/chat_api.py
+++ b/routes/chat_api.py
@@ -1,0 +1,25 @@
+from flask import Blueprint, jsonify, request, current_app
+from services.chat_manager import ChatManager
+
+chat_api_bp = Blueprint('chat_api', __name__)
+
+
+def _mgr():
+    return ChatManager(current_app.config['DB_PATH'])
+
+
+@chat_api_bp.get('/api/messages')
+def get_messages():
+    messages = _mgr().get_messages()
+    return jsonify(messages)
+
+
+@chat_api_bp.post('/api/messages')
+def post_message():
+    data = request.get_json() or {}
+    user = data.get('user')
+    text = data.get('text')
+    if not user or not text:
+        return jsonify({'error': 'Invalid data'}), 400
+    message = _mgr().add_message(user, text)
+    return jsonify(message), 201

--- a/services/chat_manager.py
+++ b/services/chat_manager.py
@@ -1,0 +1,34 @@
+import sqlite3
+from typing import List, Dict
+
+class ChatManager:
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+
+    def db_conn(self):
+        conn = sqlite3.connect(self.db_path, timeout=10, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute('PRAGMA journal_mode=WAL;')
+        conn.execute('PRAGMA synchronous=NORMAL;')
+        return conn
+
+    def add_message(self, user: str, text: str) -> Dict:
+        conn = self.db_conn()
+        cur = conn.cursor()
+        cur.execute('INSERT INTO chat_messages (user, text) VALUES (?, ?)', (user, text))
+        message_id = cur.lastrowid
+        conn.commit()
+        cur.execute('SELECT id, user, text, timestamp FROM chat_messages WHERE id=?', (message_id,))
+        row = cur.fetchone()
+        conn.close()
+        if row:
+            return dict(row)
+        return {'id': message_id, 'user': user, 'text': text, 'timestamp': None}
+
+    def get_messages(self) -> List[Dict]:
+        conn = self.db_conn()
+        cur = conn.cursor()
+        cur.execute('SELECT id, user, text, timestamp FROM chat_messages ORDER BY timestamp')
+        rows = cur.fetchall()
+        conn.close()
+        return [dict(r) for r in rows]

--- a/static/chat-widget/src/components/ChatModal.tsx
+++ b/static/chat-widget/src/components/ChatModal.tsx
@@ -95,7 +95,7 @@ export default function ChatModal({ isOpen, onClose, user }: ChatModalProps) {
 
   return (
     <div
-      className="chat-modal-overlay"
+      className="chat-modal-overlay chat-overlay"
       style={{
         position: 'fixed',
         bottom: '1rem',

--- a/static/chat-widget/src/components/ChatOverlay.tsx
+++ b/static/chat-widget/src/components/ChatOverlay.tsx
@@ -4,12 +4,11 @@ import ChatModal from './ChatModal';
 
 export default function ChatOverlay() {
   const [isOpen, setIsOpen] = useState(false);
-  const user = { username: 'Usuario_EEVI' };
 
   return (
     <>
       <UserNavPanel onOpen={() => setIsOpen(true)} />
-      <ChatModal isOpen={isOpen} onClose={() => setIsOpen(false)} user={user} />
+      <ChatModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
     </>
   );
 }

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -184,3 +184,8 @@ body {
         overflow: hidden;
     }
 }
+
+.header .btn-chat-demo { display: none !important; }
+header { z-index: 1000; position: relative; }
+.chat-overlay { z-index: 500; }
+


### PR DESCRIPTION
## Summary
- add ChatManager service and API routes for `/api/messages`
- create `chat_messages` table in schema
- integrate new API with chat widget
- allow display name editing for anonymous users
- tweak overlay z-index styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688036e4667883258ba8257f19874baa