### PR TITLE
Implement persistent chat feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,7 @@ app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(projects_bp, url_prefix='/projects')
 app.register_blueprint(messages_bp, url_prefix='/messages')
 app.register_blueprint(chat_bp, url_prefix='/chat')
-app.register_blueprint(chat_api_bp)
+app.register_blueprint(chat_api_bp, url_prefix='/api')
 
 if FRIENDS_AVAILABLE:
     app.register_blueprint(friends_bp, url_prefix='/friends')

--- a/routes/chat_api.py
+++ b/routes/chat_api.py
@@ -8,13 +8,13 @@ def _mgr():
     return ChatManager(current_app.config['DB_PATH'])
 
 
-@chat_api_bp.get('/api/messages')
+@chat_api_bp.get('/messages')
 def get_messages():
     messages = _mgr().get_messages()
     return jsonify(messages)
 
 
-@chat_api_bp.post('/api/messages')
+@chat_api_bp.post('/messages')
 def post_message():
     data = request.get_json() or {}
     user = data.get('user')

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -185,7 +185,7 @@ body {
     }
 }
 
-.header .btn-chat-demo { display: none !important; }
-header { z-index: 1000; position: relative; }
-.chat-overlay { z-index: 500; }
+.btn-chat-demo { display: none !important; }
+header { position: relative; z-index: 1000; }
+.chat-overlay { z-index: 500 !important; }
 


### PR DESCRIPTION
## Summary
- expose chat API at `/api/messages`
- register chat API blueprint in app
- replace demo chat widget with persistent version and editable nick
- tweak site styles for chat widget

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68803b9e40148325a24e60395cdf21e4