### PR TITLE
Enable real‑time chat with Socket.IO

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ google-cloud-firestore>=2.16
 
 # Google API client (for Drive previews)
 google-api-python-client>=2.127
+flask-socketio>=5.3.0

--- a/routes/chat_api.py
+++ b/routes/chat_api.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request, current_app
+from app import socketio
 from services.chat_manager import ChatManager
 
 chat_api_bp = Blueprint('chat_api', __name__)
@@ -22,4 +23,5 @@ def post_message():
     if not user or not text:
         return jsonify({'error': 'Invalid data'}), 400
     message = _mgr().add_message(user, text)
+    socketio.emit('new_message', message)
     return jsonify(message), 201

--- a/static/chat-widget/package.json
+++ b/static/chat-widget/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "lucide-react": "^0.200.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/static/chat-widget/src/ChatModal.tsx
+++ b/static/chat-widget/src/ChatModal.tsx
@@ -13,6 +13,8 @@ import {
   Minimize2,
   Maximize2,
 } from 'lucide-react';
+import { io } from 'socket.io-client';
+const socket = io();
 import { COLORS } from './COLORS';
 
 interface Message {
@@ -51,6 +53,12 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
     fetch('/api/messages')
       .then((r) => r.json())
       .then((data) => setMessages(data));
+    socket.on('new_message', (msg: Message) => {
+      setMessages((prev) => [...prev, msg]);
+    });
+    return () => {
+      socket.off('new_message');
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- emit new chat messages with SocketIO
- connect React chat widget via socket.io-client
- include socket.io-client dependency
- list Flask-SocketIO in requirements

## Testing
- `pip install -r requirements.txt` *(fails: could not connect to pypi)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run build` *(fails: esbuild not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6880e8e3b3ac8325b97be4f47b7d165f