### PR TITLE
Fix SocketIO circular import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, redirect, url_for, session, jsonify
 from datetime import datetime
 from flask_login import LoginManager, current_user, UserMixin
-from flask_socketio import SocketIO, emit
+from flask_socketio import emit
 import os
 import logging
 import time
@@ -38,7 +38,8 @@ except ImportError:
 # Configuración
 logging.basicConfig(level=logging.INFO)
 app = Flask(__name__)
-socketio = SocketIO(app, cors_allowed_origins="*")
+from extensions import socketio
+socketio.init_app(app)
 
 # --- Autenticación mínima para evitar fallos de import ---
 login_manager = LoginManager(app)

--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,6 @@
+from flask_socketio import SocketIO
+
+# SocketIO instance shared across the project.  It is created here so that
+# modules can import it without creating circular dependencies.
+socketio = SocketIO(cors_allowed_origins="*")
+

--- a/routes/chat_api.py
+++ b/routes/chat_api.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, jsonify, request, current_app
-from app import socketio
+from extensions import socketio
 from services.chat_manager import ChatManager
 
 chat_api_bp = Blueprint('chat_api', __name__)


### PR DESCRIPTION
## Summary
- provide shared `socketio` instance in `extensions.py`
- update `app.py` to initialize SocketIO using the new extension
- import the shared `socketio` in `routes/chat_api.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6880f06b217c832597fb0ed204de0b5a