### PR TITLE
Fix chat widget build and forum stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from routes.auth import auth_bp
 from routes.projects import projects_bp
 from routes.messages import messages_bp
 from routes.chat_api import chat_api_bp
+from routes.forum_stats import forum_bp as forum_stats_bp
 
 # Nuevos blueprints
 try:
@@ -96,6 +97,9 @@ if STATUS_AVAILABLE:
 
 if FORUM_AUTH_AVAILABLE:
     app.register_blueprint(forum_auth_bp, url_prefix='/forum')
+
+# Estadísticas del foro
+app.register_blueprint(forum_stats_bp, url_prefix='/forum')
 
 # ===== AGREGAR RUTAS DE FORUM FALTANTES =====
 from utils.template_filters import register_filters

--- a/build-and-copy.sh
+++ b/build-and-copy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Compile the chat widget
+npx webpack --config webpack.config.js

--- a/static/chat-widget/index.html
+++ b/static/chat-widget/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
 <body>
-  <div id="eevi-chat-root"></div>
+  <div id="chat-root"></div>
   <script type="module" src="/static/chat-widget/src/main.tsx"></script>
 </body>
 </html>

--- a/static/chat-widget/src/ChatModal.tsx
+++ b/static/chat-widget/src/ChatModal.tsx
@@ -21,7 +21,8 @@ interface Message {
   id?: number;
   text: string;
   sender: string;
-  timestamp?: number;
+  timestamp: number;
+  isSystem?: boolean;
 }
 
 interface ChatModalProps {
@@ -47,7 +48,7 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
     if (name) setDisplayName(name);
 
     socket.on('chat message', (msg: Message) => {
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) => [...prev, msg].sort((a, b) => a.timestamp - b.timestamp));
     });
 
     return () => {

--- a/static/chat-widget/src/main.tsx
+++ b/static/chat-widget/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import ChatOverlay from './components/ChatOverlay';
 
-const container = document.getElementById('eevi-chat-root');
+const container = document.getElementById('chat-root');
 if (container) {
   const root = createRoot(container);
   root.render(<ChatOverlay />);

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -189,7 +189,7 @@ body {
 header { position: relative; z-index: 1100; }
 .chat-overlay { z-index: 500 !important; }
 /* Overlay de chat debe quedar bajo el header */
-#eevi-chat-root .chat-modal-overlay {
+#chat-root .chat-modal-overlay {
   position: fixed;
   bottom: 1rem;
   right: 1rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,12 +45,8 @@
   {% endblock %}
   <script src="{{ url_for('static', filename='js/nav_unified.js') }}"></script>
   <!-- Chat Widget Root -->
-  <div id="eevi-chat-root"></div>
+  <div id="chat-root"></div>
   <!-- Carga del bundle compilado del chat -->
-  <script>
-    // Polyfill global de process para evitar 'ReferenceError: process is not defined'
-    window.process = { env: { NODE_ENV: 'production' } };
-  </script>
-  <script type="module" src="{{ url_for('static', filename='chat-widget/dist/index.js') }}"></script>
+  <script src="{{ url_for('static', filename='dist/bundle.js') }}"></script>
 </body>
 </html>

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -10,7 +10,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/modal.css') }}">
 <style>
   /* Oculta el botón por defecto del widget de chat */
-  #eevi-chat-root > button { display: none; }
+  #chat-root > button { display: none; }
 </style>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
@@ -253,7 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const customBtn  = document.getElementById('eevi-chat-toggle');
-    const widgetBtn  = document.querySelector('#eevi-chat-root > button');
+    const widgetBtn  = document.querySelector('#chat-root > button');
     if (!customBtn || !widgetBtn) return;
     customBtn.addEventListener('click', () => widgetBtn.click());
   });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  entry: './static/chat-widget/src/index.tsx',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'static/dist'),
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      }
+    ]
+  }
+};


### PR DESCRIPTION
## Summary
- connect `ChatModal` to Socket.IO and sort messages
- mount widget from `index.tsx`
- add webpack build configuration
- load bundle on every page
- register forum stats blueprint
- provide build helper script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68841396fbec832599b60016083df33f