### PR TITLE
Configure esbuild build for chat widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "private": true,
   "scripts": {
     "start": "flask run",
-    "build:chat-widget": "npm --prefix static/chat-widget ci && npm --prefix static/chat-widget run build"
+    "build": "esbuild static/chat-widget/src/index.tsx --bundle --minify --sourcemap --outfile=static/dist/bundle.js --tsconfig=static/chat-widget/tsconfig.json"
+  },
+  "dependencies": {
+    "lucide-react": "^0.200.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "socket.io-client": "^4.8.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.8",
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add dependencies and build script to package.json

## Testing
- `npm install` *(fails: 403 Forbidden due to network)*
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858c19d4908325bfec9a7adab91c41