### PR TITLE
Add build:chat-widget script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "flask run",
-    "build": "esbuild static/chat-widget/src/index.tsx --bundle --minify --sourcemap --outfile=static/dist/bundle.js --tsconfig=static/chat-widget/tsconfig.json"
+    "build": "esbuild static/chat-widget/src/index.tsx --bundle --minify --sourcemap --outfile=static/dist/bundle.js --tsconfig=static/chat-widget/tsconfig.json",
+    "build:chat-widget": "npm run build"
   },
   "dependencies": {
     "lucide-react": "^0.200.0",


### PR DESCRIPTION
## Summary
- add `build:chat-widget` script to mirror existing build step

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688594dda59483259703bae184577725