### PR TITLE
Configure root build script to run chat widget build with Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "flask run",
-    "build": "esbuild static/chat-widget/src/index.tsx --bundle --minify --sourcemap --outfile=static/dist/bundle.js --tsconfig=static/chat-widget/tsconfig.json",
-    "build:chat-widget": "npm run build"
+    "build": "npm run build:chat-widget",
+    "build:chat-widget": "cd static/chat-widget && npm install && npm run build"
   },
   "dependencies": {
     "lucide-react": "^0.200.0",
@@ -14,7 +14,7 @@
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
-    "esbuild": "^0.25.8",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- call the chat widget build from the root `build` script
- provide `build:chat-widget` script that runs the Vite build
- remove esbuild usage and add Vite as dev dependency

## Testing
- `npm run build:chat-widget` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688596ac88c88325aaa54df2a22c1b8d