### PR TITLE
Enable real-time chat via SocketIO

### DIFF
--- a/app.py
+++ b/app.py
@@ -335,7 +335,3 @@ if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))
     debug = not os.environ.get('RENDER')
     socketio.run(app, host='0.0.0.0', port=port, debug=debug)
-
-if __name__ == '__main__':
-    socketio.init_app(app)
-    socketio.run(app, host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- remove duplicated `__main__` block in `app.py`
- wire ChatModal component with SocketIO join/leave/events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm run build` *(fails to install packages - no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68867ac1c8dc832587789aa739dede65