### PR TITLE
Fix socket import in chat widget

### DIFF
--- a/static/chat-widget/src/components/ChatModal.tsx
+++ b/static/chat-widget/src/components/ChatModal.tsx
@@ -14,7 +14,7 @@ import {
   Maximize2,
 } from 'lucide-react';
 import { COLORS } from '../COLORS';
-import socket from '../socket';
+import { socket } from '../socket';
 
 interface Message {
   id?: number;

--- a/static/chat-widget/src/socket.ts
+++ b/static/chat-widget/src/socket.ts
@@ -1,9 +1,7 @@
 import { io } from 'socket.io-client';
 
-const socket = io('/', {
+export const socket = io('/', {
   path: '/socket.io',
   transports: ['websocket'],
   withCredentials: true,
 });
-
-export default socket;


### PR DESCRIPTION
## Summary
- use named socket export for chat widget socket
- update ChatModal to use named import

## Testing
- `npm run build:chat-widget` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68867c6648d88325be54c5f23e8c66c4