### PR TITLE
Fix Socket.IO handling in chat widget

### DIFF
--- a/static/chat-widget/src/components/ChatModal.tsx
+++ b/static/chat-widget/src/components/ChatModal.tsx
@@ -55,14 +55,21 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
       .then((r) => r.json())
       .then((data) => setMessages(data));
 
-    socket.emit('join', { chat_id: chatId });
-    socket.on('message', (msg: Message) => {
+    if (!socket.connected) {
+      socket.connect();
+    }
+
+    const onMessage = (msg: Message) => {
       setMessages((prev) => [...prev, msg]);
-    });
+    };
+
+    socket.emit('join', { chat_id: chatId });
+    socket.on('message', onMessage);
 
     return () => {
       socket.emit('leave', { chat_id: chatId });
-      socket.off('message');
+      socket.off('message', onMessage);
+      socket.disconnect();
     };
   }, []);
 

--- a/static/chat-widget/src/socket.js
+++ b/static/chat-widget/src/socket.js
@@ -2,5 +2,8 @@
 import { io } from "socket.io-client";
 
 export const socket = io("/", {
+  path: "/socket.io",
+  transports: ["websocket"],
+  withCredentials: true,
   autoConnect: false,
 });

--- a/static/chat-widget/src/socket.ts
+++ b/static/chat-widget/src/socket.ts
@@ -4,4 +4,5 @@ export const socket = io('/', {
   path: '/socket.io',
   transports: ['websocket'],
   withCredentials: true,
+  autoConnect: false,
 });


### PR DESCRIPTION
## Summary
- connect to Socket.IO in `ChatModal`
- listen/leave room correctly
- configure exported socket to disable auto-connect

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886a8cf53b083258d469f2a9e0aa8fb