### PR TITLE
Add IDs and names to form elements

### DIFF
--- a/static/chat-widget/src/components/ChatModal.tsx
+++ b/static/chat-widget/src/components/ChatModal.tsx
@@ -265,12 +265,17 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
               <span style={{ fontSize: '0.75rem', color: COLORS.accent }}>Conectado como:</span>
               {editingName ? (
                 <input
+                  id="chat-display-name"
+                  name="displayName"
+                  type="text"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
                   onBlur={() => {
                     setEditingName(false);
                     localStorage.setItem('displayName', displayName);
                   }}
+                  placeholder="Tu nombre"
+                  autoComplete="username"
                   style={{ fontSize: '0.75rem' }}
                 />
               ) : (
@@ -287,11 +292,15 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <input
                 ref={inputRef}
+                id="chat-message-input"
+                name="message"
                 type="text"
                 value={inputMessage}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInputMessage(e.target.value)}
                 onKeyPress={handleKeyPress}
                 placeholder="Escribe tu mensaje..."
+                autoComplete="off"
+                autoCapitalize="sentences"
                 style={{
                   flex: 1,
                   padding: '0.5rem',

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -20,7 +20,7 @@
     <header class="header">
       <h2>Panel Admin</h2>
       <form action="{{ url_for('admin.admin_logout') }}" method="post" class="inline-form">
-        <button type="submit" class="btn btn-danger">Salir</button>
+        <button id="admin-logout" name="submit" type="submit" class="btn btn-danger">Salir</button>
       </form>
     </header>
 
@@ -63,11 +63,11 @@
 
     <div class="dashboard-login mb-1">
       <form action="{{ url_for('admin.admin_add_project') }}" method="post">
-        <input type="text" name="title" placeholder="Título" required class="form-control full-input">
-        <input type="text" name="category" placeholder="Categoría" required class="form-control full-input">
-        <input type="text" name="video_url" placeholder="URL" required class="form-control full-input">
-        <input type="email" name="client_email" placeholder="Cliente" required class="form-control full-input">
-        <button type="submit" class="btn btn-primary">Agregar</button>
+        <input id="admin-project-title" name="title" type="text" placeholder="Título" autoComplete="off" required class="form-control full-input">
+        <input id="admin-project-category" name="category" type="text" placeholder="Categoría" autoComplete="off" required class="form-control full-input">
+        <input id="admin-project-video" name="video_url" type="text" placeholder="URL" autoComplete="off" required class="form-control full-input">
+        <input id="admin-project-email" name="client_email" type="email" placeholder="Cliente" autoComplete="email" required class="form-control full-input">
+        <button id="admin-project-submit" name="submit" type="submit" class="btn btn-primary">Agregar</button>
       </form>
     </div>
 
@@ -76,19 +76,19 @@
       <div class="project-card card">
         <h4>{{ p.title }}</h4>
         <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
-          <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" class="form-control full-input">
-          <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" class="form-control full-input">
-          <button type="submit" class="btn btn-primary">Guardar</button>
+          <input id="admin-project-video-url" name="video_url" type="text" value="{{ p.video_url }}" placeholder="URL de video" autoComplete="off" class="form-control full-input">
+          <input id="admin-project-client" name="client_email" type="email" value="{{ p.client_email }}" placeholder="Cliente" autoComplete="email" class="form-control full-input">
+          <button id="admin-project-save" name="submit" type="submit" class="btn btn-primary">Guardar</button>
         </form>
         <form action="{{ url_for('admin.admin_activate_payment', project_id=p.id) }}" method="post" class="mt-half">
           {% if not p.paid %}
-          <button type="submit" class="btn btn-success pay-btn">Activar 50%</button>
+          <button id="admin-activate-payment" name="submit" type="submit" class="btn btn-success pay-btn">Activar 50%</button>
           {% else %}
           <span>Pago activado</span>
           {% endif %}
         </form>
         <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" class="mt-half">
-          <button type="submit" class="btn btn-danger">Eliminar Video</button>
+          <button id="admin-delete-video" name="submit" type="submit" class="btn btn-danger">Eliminar Video</button>
         </form>
       </div>
       {% endfor %}

--- a/templates/admin/header.html
+++ b/templates/admin/header.html
@@ -1,7 +1,7 @@
 <header class="header">
   <div class="logo">EEVI</div>
   <form class="search-bar">
-    <input type="text" class="form-control" placeholder="Buscar" />
+    <input id="search-admin" name="search" type="text" class="form-control" placeholder="Buscar" autoComplete="off" />
   </form>
   <div class="header-actions">
     <i class="fa fa-bell"></i>

--- a/templates/admin/pack_form.html
+++ b/templates/admin/pack_form.html
@@ -4,8 +4,8 @@
 <form method="post">
   {% for field in ['name','slug','description','price','image_url'] %}
     <label>{{ field.replace('_',' ').title() }}</label>
-    <input name="{{ field }}" value="{{ pack[field] if pack else '' }}" required>
+    <input id="admin-{{ field }}" name="{{ field }}" value="{{ pack[field] if pack else '' }}" required>
   {% endfor %}
-  <button class="btn btn-primary">{{ pack and 'Actualizar' or 'Crear' }}</button>
+  <button id="admin-pack-submit" name="submit" type="submit" class="btn btn-primary">{{ pack and 'Actualizar' or 'Crear' }}</button>
 </form>
 {% endblock %}

--- a/templates/admin/packs_list.html
+++ b/templates/admin/packs_list.html
@@ -14,8 +14,8 @@
       <td>
         <a href="{{ url_for('admin.pack_edit', id=p.id) }}" class="btn btn-secondary">Editar</a>
         <form action="{{ url_for('admin.pack_delete', id=p.id) }}" method="post" style="display:inline">
-          <input type="password" name="password" placeholder="Clave" required>
-          <button class="btn btn-danger">Eliminar</button>
+          <input id="admin-pack-password" name="password" type="password" placeholder="Clave" autoComplete="current-password" required>
+          <button id="admin-pack-delete" name="submit" type="submit" class="btn btn-danger">Eliminar</button>
         </form>
       </td>
     </tr>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -47,11 +47,11 @@
 
 <div class="dashboard-login mb-1">
   <form action="{{ url_for('admin.admin_add_project') }}" method="post">
-    <input type="text" name="title" placeholder="Título" required class="form-control full-input">
-    <input type="text" name="category" placeholder="Categoría" required class="form-control full-input">
-    <input type="text" name="video_url" placeholder="URL" required class="form-control full-input">
-    <input type="email" name="client_email" placeholder="Cliente" required class="form-control full-input">
-    <button type="submit" class="btn btn-primary">Agregar</button>
+      <input id="admin-project-title" name="title" type="text" placeholder="Título" autoComplete="off" required class="form-control full-input">
+      <input id="admin-project-category" name="category" type="text" placeholder="Categoría" autoComplete="off" required class="form-control full-input">
+      <input id="admin-project-video" name="video_url" type="text" placeholder="URL" autoComplete="off" required class="form-control full-input">
+      <input id="admin-project-email" name="client_email" type="email" placeholder="Cliente" autoComplete="email" required class="form-control full-input">
+      <button id="admin-project-submit" name="submit" type="submit" class="btn btn-primary">Agregar</button>
   </form>
 </div>
 <div class="projects">
@@ -59,19 +59,19 @@
   <div class="project-card card">
     <h4>{{ p.title }}</h4>
     <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
-      <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" class="form-control full-input">
-      <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" class="form-control full-input">
-      <button type="submit" class="btn btn-primary">Guardar</button>
+      <input id="admin-project-video-url" name="video_url" type="text" value="{{ p.video_url }}" placeholder="URL de video" autoComplete="off" class="form-control full-input">
+      <input id="admin-project-client" name="client_email" type="email" value="{{ p.client_email }}" placeholder="Cliente" autoComplete="email" class="form-control full-input">
+      <button id="admin-project-save" name="submit" type="submit" class="btn btn-primary">Guardar</button>
     </form>
     <form action="{{ url_for('admin.admin_activate_payment', project_id=p.id) }}" method="post" class="mt-half">
       {% if not p.paid %}
-      <button type="submit" class="btn btn-success pay-btn">Activar 50%</button>
+      <button id="admin-activate-payment" name="submit" type="submit" class="btn btn-success pay-btn">Activar 50%</button>
       {% else %}
       <span>Pago activado</span>
       {% endif %}
     </form>
     <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" class="mt-half">
-      <button type="submit" class="btn btn-danger">Eliminar Video</button>
+      <button id="admin-delete-video" name="submit" type="submit" class="btn btn-danger">Eliminar Video</button>
     </form>
   </div>
   {% endfor %}

--- a/templates/admin_login_form.html
+++ b/templates/admin_login_form.html
@@ -5,9 +5,9 @@
   <div class="dashboard-login">
     <h2>Ingresar como admin</h2>
     <form method="POST">
-      <input type="email" name="email" placeholder="Email" required>
-      <input type="password" name="password" placeholder="Contrase\u00f1a" required>
-      <button type="submit">Entrar</button>
+      <input id="auth-email" name="email" type="email" placeholder="Email" autoComplete="email" required>
+      <input id="auth-password" name="password" type="password" placeholder="Contrase\u00f1a" autoComplete="current-password" required>
+      <button id="auth-login-submit" name="submit" type="submit">Entrar</button>
     </form>
   </div>
 </div>

--- a/templates/admin_pack_form.html
+++ b/templates/admin_pack_form.html
@@ -3,11 +3,11 @@
 {% block admin_content %}
 <h2>{{ 'Editar' if pack else 'Nuevo' }} Pack</h2>
 <form method="post">
-  <input type="text" name="slug" placeholder="Slug" value="{{ pack['slug'] if pack else '' }}" {% if pack %}readonly{% endif %} required class="form-control full-input">
-  <input type="text" name="name" placeholder="Nombre" value="{{ pack['name'] if pack else '' }}" required class="form-control full-input">
-  <textarea name="description" placeholder="Descripción" class="form-control full-input">{{ pack['description'] if pack else '' }}</textarea>
-  <input type="text" name="price" placeholder="Precio" value="{{ pack['price'] if pack else '' }}" required class="form-control full-input">
-  <input type="text" name="image" placeholder="Imagen" value="{{ pack['image'] if pack else '' }}" class="form-control full-input">
-  <button type="submit" class="btn btn-primary">Guardar</button>
+  <input id="admin-pack-slug" name="slug" type="text" placeholder="Slug" value="{{ pack['slug'] if pack else '' }}" {% if pack %}readonly{% endif %} required class="form-control full-input">
+  <input id="admin-pack-name" name="name" type="text" placeholder="Nombre" value="{{ pack['name'] if pack else '' }}" required class="form-control full-input">
+  <textarea id="admin-pack-description" name="description" placeholder="Descripción" class="form-control full-input">{{ pack['description'] if pack else '' }}</textarea>
+  <input id="admin-pack-price" name="price" type="text" placeholder="Precio" value="{{ pack['price'] if pack else '' }}" required class="form-control full-input">
+  <input id="admin-pack-image" name="image" type="text" placeholder="Imagen" value="{{ pack['image'] if pack else '' }}" class="form-control full-input">
+  <button id="admin-pack-submit" name="submit" type="submit" class="btn btn-primary">Guardar</button>
 </form>
 {% endblock %}

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -29,7 +29,7 @@
         <header class="page-header">
           <h2>Panel de Administración</h2>
           <form action="{{ url_for('admin.admin_logout') }}" method="post" class="inline-form">
-            <button type="submit" class="btn btn-danger">Salir</button>
+            <button id="admin-logout" name="submit" type="submit" class="btn btn-danger">Salir</button>
           </form>
         </header>
 
@@ -51,11 +51,11 @@
         <div class="card">
           <h3>Agregar Nuevo Proyecto</h3>
           <form action="{{ url_for('admin.admin_add_project') }}" method="post">
-            <input type="text" name="title" placeholder="Título del proyecto" required class="form-control">
-            <input type="text" name="category" placeholder="Categoría" required class="form-control">
-            <input type="text" name="video_url" placeholder="URL del video" required class="form-control">
-            <input type="email" name="client_email" placeholder="Email del cliente" required class="form-control">
-            <button type="submit" class="btn btn-primary">Agregar Proyecto</button>
+            <input id="admin-project-title" name="title" type="text" placeholder="Título del proyecto" autoComplete="off" required class="form-control">
+            <input id="admin-project-category" name="category" type="text" placeholder="Categoría" autoComplete="off" required class="form-control">
+            <input id="admin-project-video" name="video_url" type="text" placeholder="URL del video" autoComplete="off" required class="form-control">
+            <input id="admin-project-email" name="client_email" type="email" placeholder="Email del cliente" autoComplete="email" required class="form-control">
+            <button id="admin-project-submit" name="submit" type="submit" class="btn btn-primary">Agregar Proyecto</button>
           </form>
         </div>
 
@@ -66,11 +66,11 @@
             <span class="close-modal" style="float: right; cursor: pointer; font-size: 1.5rem;">&times;</span>
             <h3>Subir Video</h3>
             <form class="project-form" action="{{ url_for('admin.admin_upload_project') }}" method="post" enctype="multipart/form-data">
-              <input type="text" name="title" placeholder="Título" required class="form-control">
-              <input type="text" name="category" placeholder="Categoría" required class="form-control">
-              <input type="file" name="video_file" accept="video/*" required class="form-control">
-              <input type="email" name="client_email" placeholder="Email del cliente" required class="form-control">
-              <button type="submit" class="btn btn-primary">Subir</button>
+              <input id="admin-upload-title" name="title" type="text" placeholder="Título" autoComplete="off" required class="form-control">
+              <input id="admin-upload-category" name="category" type="text" placeholder="Categoría" autoComplete="off" required class="form-control">
+              <input id="admin-upload-file" name="video_file" type="file" accept="video/*" required class="form-control">
+              <input id="admin-upload-email" name="client_email" type="email" placeholder="Email del cliente" autoComplete="email" required class="form-control">
+              <button id="admin-upload-submit" name="submit" type="submit" class="btn btn-primary">Subir</button>
             </form>
           </div>
         </div>
@@ -81,29 +81,29 @@
             <h4>{{ p.title }}</h4>
             <span class="status-badge status-{{ p.status }}">{{ p.status }}</span>
             
-            <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
-              <input type="text" name="video_url" value="{{ p.video_url }}" placeholder="URL de video" class="form-control">
-              <input type="email" name="client_email" value="{{ p.client_email }}" placeholder="Cliente" class="form-control">
-              <button type="submit" class="btn btn-primary">Guardar</button>
-            </form>
+          <form action="{{ url_for('admin.admin_update_project', project_id=p.id) }}" method="post">
+              <input id="admin-project-video-url" name="video_url" type="text" value="{{ p.video_url }}" placeholder="URL de video" autoComplete="off" class="form-control">
+              <input id="admin-project-client" name="client_email" type="email" value="{{ p.client_email }}" placeholder="Cliente" autoComplete="email" class="form-control">
+              <button id="admin-project-save" name="submit" type="submit" class="btn btn-primary">Guardar</button>
+          </form>
             
             <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
               <form action="{{ url_for('admin.admin_activate_payment', project_id=p.id) }}" method="post" style="display: inline;">
                 {% if not p.paid %}
-                <button type="submit" class="btn btn-success">Activar 50%</button>
+                <button id="admin-activate-payment" name="submit" type="submit" class="btn btn-success">Activar 50%</button>
                 {% else %}
                 <span style="color: var(--admin-success);">✓ Pago activado</span>
                 {% endif %}
               </form>
               
               <form action="{{ url_for('admin.admin_update_status', project_id=p.id) }}" method="post" class="status-form" style="display: inline;">
-                <button type="submit" name="status" value="revision" class="btn">En revisión</button>
-                <button type="submit" name="status" value="finalizado" class="btn">Finalizado</button>
-                <button type="submit" name="status" value="pagado" class="btn">Pagado</button>
+                <button id="admin-status-revision" name="status" value="revision" type="submit" class="btn">En revisión</button>
+                <button id="admin-status-finalizado" name="status" value="finalizado" type="submit" class="btn">Finalizado</button>
+                <button id="admin-status-pagado" name="status" value="pagado" type="submit" class="btn">Pagado</button>
               </form>
               
               <form action="{{ url_for('admin.admin_delete_video', project_id=p.id) }}" method="post" onsubmit="return confirmDelete();" style="display: inline;">
-                <button type="submit" class="btn btn-danger">Eliminar Video</button>
+                <button id="admin-delete-video" name="submit" type="submit" class="btn btn-danger">Eliminar Video</button>
               </form>
             </div>
           </div>
@@ -123,21 +123,21 @@
       <div id="clientes" class="section hidden" style="display:none;">
         <h2>Gestión de Clientes</h2>
         <form action="{{ url_for('admin.add_client') }}" method="post" class="mb-1">
-          <input type="email" name="email" placeholder="Email" required class="form-control full-input">
-          <input type="text" name="password" placeholder="Contraseña" required class="form-control full-input">
-          <button type="submit" class="btn btn-primary">Agregar</button>
+          <input id="admin-client-email" name="email" type="email" placeholder="Email" autoComplete="email" required class="form-control full-input">
+          <input id="admin-client-password" name="password" type="text" placeholder="Contraseña" autoComplete="new-password" required class="form-control full-input">
+          <button id="admin-client-submit" name="submit" type="submit" class="btn btn-primary">Agregar</button>
         </form>
         <ul class="clients-list">
           {% for c in clients %}
           <li>
             <strong>{{ c.email }}</strong>
-            <form action="{{ url_for('admin.update_password', user_id=c.id) }}" method="post" class="inline-form">
-              <input type="text" name="password" placeholder="Nueva contraseña" class="form-control">
-              <button type="submit" class="btn btn-sm">Guardar</button>
-            </form>
-            <form action="{{ url_for('admin.delete_client', user_id=c.id) }}" method="post" class="inline-form" onsubmit="return confirm('¿Eliminar cliente?');">
-              <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
-            </form>
+              <form action="{{ url_for('admin.update_password', user_id=c.id) }}" method="post" class="inline-form">
+                <input id="admin-user-password" name="password" type="text" placeholder="Nueva contraseña" autoComplete="new-password" class="form-control">
+                <button id="admin-user-save" name="submit" type="submit" class="btn btn-sm">Guardar</button>
+              </form>
+              <form action="{{ url_for('admin.delete_client', user_id=c.id) }}" method="post" class="inline-form" onsubmit="return confirm('¿Eliminar cliente?');">
+                <button id="admin-client-delete" name="submit" type="submit" class="btn btn-danger btn-sm">Eliminar</button>
+              </form>
           </li>
           {% endfor %}
         </ul>

--- a/templates/admin_signup.html
+++ b/templates/admin_signup.html
@@ -5,9 +5,9 @@
   <div class="dashboard-login">
     <h2>Crear admin</h2>
     <form method="POST">
-      <input type="email" name="email" placeholder="Email" required>
-      <input type="password" name="password" placeholder="Contrase\u00f1a" required>
-      <button type="submit">Crear</button>
+      <input id="auth-email" name="email" type="email" placeholder="Email" autoComplete="email" required>
+      <input id="auth-password" name="password" type="password" placeholder="Contrase\u00f1a" autoComplete="new-password" required>
+      <button id="auth-admin-submit" name="submit" type="submit">Crear</button>
     </form>
   </div>
 </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -29,7 +29,7 @@
     <div class="header-actions">
       <button id="theme-toggle" class="dash-btn dash-btn-secondary">🌙 Modo</button>
       <form action="{{ url_for('client.logout') }}" method="post" style="display:inline;">
-        <button type="submit" class="dash-btn dash-btn-primary">Salir</button>
+        <button id="auth-logout" name="submit" type="submit" class="dash-btn dash-btn-primary">Salir</button>
       </form>
     </div>
   </div>
@@ -99,8 +99,8 @@
         <h3>Mi Perfil</h3>
         <img src="{{ user.profile_pic or url_for('static', filename='img/avatar.png') }}" alt="Foto de perfil" class="profile-pic">
         <form action="{{ url_for('client.upload_profile') }}" method="post" enctype="multipart/form-data">
-          <input type="file" name="photo" accept="image/*" required style="margin-bottom: 1rem;">
-          <button type="submit" class="dash-btn dash-btn-primary" style="width: 100%;">Actualizar foto</button>
+          <input id="profile-photo" name="photo" type="file" accept="image/*" required style="margin-bottom: 1rem;">
+          <button id="profile-submit" name="submit" type="submit" class="dash-btn dash-btn-primary" style="width: 100%;">Actualizar foto</button>
         </form>
       </div>
     </aside>

--- a/templates/dashboard_login.html
+++ b/templates/dashboard_login.html
@@ -5,9 +5,9 @@
   <div class="dashboard-login">
     <h2>Ingresar</h2>
     <form method="POST">
-      <input type="email" name="email" placeholder="Email" required>
-      <input type="password" name="password" placeholder="Contrase\u00f1a" required>
-      <button type="submit">Entrar</button>
+      <input id="auth-email" name="email" type="email" placeholder="Email" autoComplete="email" required>
+      <input id="auth-password" name="password" type="password" placeholder="Contrase\u00f1a" autoComplete="current-password" required>
+      <button id="auth-login-submit" name="submit" type="submit">Entrar</button>
     </form>
   </div>
 </div>

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -96,7 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <form id="topicForm" action="{{ url_for('create_new_forum') }}" method="post">
                 <div class="form-group">
                     <label class="form-label" for="autor">Nombre:</label>
-                    <input type="text" id="autor" name="autor" class="form-input" placeholder="Tu nombre" required>
+                    <input type="text" id="autor" name="autor" class="form-input" placeholder="Tu nombre" autoComplete="name" required>
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="categoria">Categoría:</label>
@@ -109,15 +109,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="titulo">Título:</label>
-                    <input type="text" id="titulo" name="titulo" class="form-input" placeholder="Un título descriptivo para tu tema" required>
+                    <input type="text" id="titulo" name="titulo" class="form-input" placeholder="Un título descriptivo para tu tema" autoComplete="off" required>
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="contenido">Contenido:</label>
-                    <textarea id="contenido" name="contenido" class="form-textarea" placeholder="Describe tu problema, pregunta o comparte tu conocimiento..." required></textarea>
+                    <textarea id="contenido" name="contenido" class="form-textarea" placeholder="Describe tu problema, pregunta o comparte tu conocimiento..." autoComplete="off" required></textarea>
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn-secondary" id="cancelBtn">Cancelar</button>
-                    <button type="submit" class="cta-button">Publicar Tema</button>
+                    <button id="forum-submit" name="submit" type="submit" class="cta-button">Publicar Tema</button>
                 </div>
             </form>
         </div>

--- a/templates/forum_detail.html
+++ b/templates/forum_detail.html
@@ -14,10 +14,10 @@
   </div>
   <div class="topic-content">{{ topic.description or topic.contenido }}</div>
   {% if show_delete %}
-  <form action="{{ url_for('delete_topic_route', topic_id=topic.id) }}" method="post">
+    <form action="{{ url_for('delete_topic_route', topic_id=topic.id) }}" method="post">
     <input type="hidden" name="password" value="borrar1">
-    <button type="submit" class="btn-delete">🗑 Eliminar</button>
-  </form>
+    <button id="forum-delete" name="submit" type="submit" class="btn-delete">🗑 Eliminar</button>
+    </form>
   {% endif %}
   <hr>
   {% for r in responses %}
@@ -30,8 +30,8 @@
   {% endfor %}
   <form class="reply-form" action="{{ url_for('forum_reply', topic_id=topic.id) }}" method="post">
     <input type="hidden" name="author" value="{{ session.get('user', 'Anónimo') }}">
-    <textarea name="content" rows="4" required></textarea>
-    <button type="submit" class="btn-primary">Responder</button>
+    <textarea id="forum-content" name="content" rows="4" placeholder="Contenido" autoComplete="off" required></textarea>
+    <button id="forum-submit" name="submit" type="submit" class="btn-primary">Responder</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,11 +4,11 @@
 <div class="dashboard-container">
   <div class="dashboard-login">
     <h2>Ingresar</h2>
-    <form method="POST">
-      <input type="email" name="email" placeholder="Email" required>
-      <input type="password" name="password" placeholder="Contraseña" required>
-      <button type="submit">Entrar</button>
-    </form>
+      <form method="POST">
+        <input id="auth-email" name="email" type="email" placeholder="Email" autoComplete="email" required>
+        <input id="auth-password" name="password" type="password" placeholder="Contraseña" autoComplete="current-password" required>
+        <button id="auth-login-submit" name="submit" type="submit">Entrar</button>
+      </form>
   </div>
 </div>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -5,10 +5,10 @@
   <div class="dashboard-login">
     <h2>Crear cuenta</h2>
     <form method="POST">
-      <input type="email" name="email" placeholder="Email" required>
-      <input type="text" name="username" placeholder="Nombre de usuario" required>
-      <input type="password" name="password" placeholder="Contraseña" required>
-      <button type="submit">Registrar</button>
+      <input id="auth-email" name="email" type="email" placeholder="Email" autoComplete="email" required>
+      <input id="auth-username" name="username" type="text" placeholder="Nombre de usuario" autoComplete="username" required>
+      <input id="auth-password" name="password" type="password" placeholder="Contraseña" autoComplete="new-password" required>
+      <button id="auth-register-submit" name="submit" type="submit">Registrar</button>
     </form>
   </div>
 </div>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -5,9 +5,9 @@
   <div class="dashboard-login">
     <h2>Crear usuario</h2>
     <form method="POST">
-      <input type="email" name="email" placeholder="Email" required>
-      <input type="password" name="password" placeholder="Contrase\u00f1a" required>
-      <button type="submit">Crear</button>
+      <input id="auth-email" name="email" type="email" placeholder="Email" autoComplete="email" required>
+      <input id="auth-password" name="password" type="password" placeholder="Contrase\u00f1a" autoComplete="new-password" required>
+      <button id="auth-signup-submit" name="submit" type="submit">Crear</button>
     </form>
   </div>
 </div>

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -6,8 +6,8 @@
     <h2>Verificar email</h2>
     <form method="POST">
       <input type="hidden" name="email" value="{{ email }}">
-      <input type="text" name="code" placeholder="Codigo" required>
-      <button type="submit">Verificar</button>
+      <input id="auth-code" name="code" type="text" placeholder="Codigo" autoComplete="off" required>
+      <button id="auth-verify-submit" name="submit" type="submit">Verificar</button>
     </form>
   </div>
 </div>

--- a/templates/vforum_auth.html
+++ b/templates/vforum_auth.html
@@ -184,18 +184,15 @@
         <div id="registerForm" class="form-container">
             <form id="register-form">
                 <div class="form-group">
-                    <input type="text" name="username" class="form-input" 
-                           placeholder="Nombre de usuario" required>
+                    <input id="auth-register-username" name="username" type="text" class="form-input" placeholder="Nombre de usuario" autoComplete="username" required>
                 </div>
                 <div class="form-group">
-                    <input type="email" name="email" class="form-input" 
-                           placeholder="Correo electrónico" required>
+                    <input id="auth-register-email" name="email" type="email" class="form-input" placeholder="Correo electrónico" autoComplete="email" required>
                 </div>
                 <div class="form-group">
-                    <input type="password" name="password" class="form-input" 
-                           placeholder="Contraseña" required minlength="6">
+                    <input id="auth-register-password" name="password" type="password" class="form-input" placeholder="Contraseña" autoComplete="new-password" required minlength="6">
                 </div>
-                <button type="submit" class="auth-button">Registrarme</button>
+                <button id="auth-register-submit" name="submit" type="submit" class="auth-button">Registrarme</button>
             </form>
             
             <div class="auth-toggle">
@@ -212,14 +209,12 @@
             </p>
             <form onsubmit="handleLogin(event)">
                 <div class="form-group">
-                    <input type="email" name="email" class="form-input" 
-                           placeholder="Correo electrónico" required>
+                    <input id="auth-login-email" name="email" type="email" class="form-input" placeholder="Correo electrónico" autoComplete="email" required>
                 </div>
                 <div class="form-group">
-                    <input type="password" name="password" class="form-input" 
-                           placeholder="Contraseña" required>
+                    <input id="auth-login-password" name="password" type="password" class="form-input" placeholder="Contraseña" autoComplete="current-password" required>
                 </div>
-                <button type="submit" class="auth-button">Ingresar</button>
+                <button id="auth-login-submit" name="submit" type="submit" class="auth-button">Ingresar</button>
             </form>
             
             <div class="auth-toggle">


### PR DESCRIPTION
## Summary
- add accessible ids and names in ChatModal inputs
- add ids and autocomplete attributes to templates for auth, admin and forum forms

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6886ed0cabb4832595295707b656fa6f