### PR TITLE
Implement unique chat user IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,29 +121,55 @@ def inject_global_vars():
 # ----- APIs de chat -----
 @app.route('/api/messages', methods=['GET'])
 def api_get_messages():
-    chat_id = request.args.get('chat_id', 'global')
-    messages = sockets.get_messages_for_api(chat_id)
-    return jsonify(messages)
+    try:
+        chat_id = request.args.get('chat_id', 'global')
+        messages = sockets.get_messages_for_api(chat_id)
+        
+        # Log para debugging
+        print(f"📡 API: Enviando {len(messages)} mensajes para sala {chat_id}")
+        
+        return jsonify(messages)
+    except Exception as e:
+        print(f"❌ Error en API get_messages: {e}")
+        return jsonify([]), 500
 
 
 @app.route('/api/messages', methods=['POST'])
 def api_post_message():
-    data = request.get_json()
-    chat_id = data.get('chat_id', 'global')
+    try:
+        data = request.get_json()
+        chat_id = data.get('chat_id', 'global')
+        
+        message = {
+            'id': len(sockets.messages_store) + 1,
+            'text': data.get('text', ''),
+            'sender': data.get('sender', 'Anónimo'),
+            'timestamp': data.get('timestamp', int(datetime.now().timestamp() * 1000)),
+            'chat_id': chat_id,
+            'isSystem': False
+        }
+        
+        sockets.messages_store.append(message)
+        
+        # Emitir via socket Y forzar polling update
+        socketio.emit('message', message, room=chat_id)
+        
+        print(f"💬 API: Mensaje guardado y emitido - ID: {message['id']}")
+        
+        return jsonify(message)
+    except Exception as e:
+        print(f"❌ Error en API post_message: {e}")
+        return jsonify({'error': str(e)}), 500
 
-    message = {
-        'id': len(sockets.messages_store) + 1,
-        'text': data.get('text', ''),
-        'sender': data.get('user', data.get('sender', 'Anónimo')),
-        'timestamp': int(datetime.now().timestamp() * 1000),
-        'chat_id': chat_id,
-        'isSystem': False
-    }
 
-    sockets.messages_store.append(message)
-    socketio.emit('message', message, room=chat_id)
-
-    return jsonify(message)
+@app.route('/api/debug/users')
+def debug_users():
+    """Debug: Ver usuarios conectados"""
+    try:
+        from sockets import get_connected_users_info
+        return jsonify(get_connected_users_info())
+    except:
+        return jsonify({'error': 'No disponible'}), 500
 
 # ===== RUTAS DE FORUM PRINCIPALES =====
 @app.route('/forum')

--- a/sockets.py
+++ b/sockets.py
@@ -5,58 +5,138 @@ import json
 
 socketio = SocketIO(cors_allowed_origins="*", async_mode='eventlet')
 
-# Store global para mensajes
+# Store global para mensajes y usuarios conectados
 messages_store = []
+connected_users = {}  # {socket_id: {userId, displayName, rooms}}
 
 @socketio.on('connect')
-def handle_connect():
-    print(f'✅ Cliente conectado: {request.sid}')
-    emit('status', {'connected': True, 'id': request.sid})
+def handle_connect(auth):
+    user_id = auth.get('userId', f'anon_{request.sid}') if auth else f'anon_{request.sid}'
+    display_name = auth.get('displayName', 'Anónimo') if auth else 'Anónimo'
+
+    connected_users[request.sid] = {
+        'userId': user_id,
+        'displayName': display_name,
+        'rooms': [],
+        'connectedAt': datetime.now().isoformat()
+    }
+
+    print(f'✅ Usuario conectado: {user_id} ({display_name}) - Socket: {request.sid}')
+    emit('user_registered', {
+        'userId': user_id,
+        'socketId': request.sid,
+        'status': 'connected'
+    })
 
 @socketio.on('disconnect')
 def handle_disconnect():
-    print(f'❌ Cliente desconectado: {request.sid}')
+    user_info = connected_users.pop(request.sid, {})
+    user_id = user_info.get('userId', 'unknown')
+    print(f'❌ Usuario desconectado: {user_id} - Socket: {request.sid}')
 
 @socketio.on('join')
 def handle_join(data):
     room = data.get('chat_id', 'global')
+    user_id = data.get('userId', 'unknown')
+
     join_room(room)
-    username = session.get('forum_user', {}).get('username', 'Anónimo')
-    print(f'👥 {username} ({request.sid}) joined room {room}')
-    
-    # Enviar historial inmediatamente
+
+    if request.sid in connected_users:
+        if room not in connected_users[request.sid]['rooms']:
+            connected_users[request.sid]['rooms'].append(room)
+
+    print(f'👥 Usuario {user_id} se unió a sala {room} - Socket: {request.sid}')
+
     room_messages = [msg for msg in messages_store if msg.get('chat_id') == room]
     recent_messages = room_messages[-50:] if room_messages else []
-    emit('message_history', recent_messages)
+    emit('message_history', {
+        'messages': recent_messages,
+        'room': room,
+        'count': len(recent_messages)
+    })
+
+    emit('user_joined', {
+        'userId': user_id,
+        'room': room,
+        'timestamp': datetime.now().isoformat()
+    }, room=room, include_self=False)
 
 @socketio.on('leave')
 def handle_leave(data):
     room = data.get('chat_id', 'global')
+    user_id = data.get('userId', 'unknown')
+
     leave_room(room)
-    print(f'👋 Cliente salió de room {room}')
+
+    if request.sid in connected_users:
+        if room in connected_users[request.sid]['rooms']:
+            connected_users[request.sid]['rooms'].remove(room)
+
+    print(f'👋 Usuario {user_id} salió de sala {room}')
+
+    emit('user_left', {
+        'userId': user_id,
+        'room': room,
+        'timestamp': datetime.now().isoformat()
+    }, room=room, include_self=False)
 
 @socketio.on('new_message')
 def handle_new_message(data):
     room = data.get('chat_id', 'global')
-    
+    user_id = data.get('userId', 'unknown')
+    sender_name = data.get('sender', 'Anónimo')
+
+    user_info = connected_users.get(request.sid)
+    if not user_info:
+        emit('error', {'message': 'Usuario no registrado'})
+        return
+
+    verified_user_id = user_info['userId']
+
     message = {
         'id': len(messages_store) + 1,
         'text': data.get('text', ''),
-        'sender': data.get('sender', 'Anónimo'),
+        'sender': sender_name,
+        'userId': verified_user_id,
+        'socketId': request.sid,
         'timestamp': data.get('timestamp', int(datetime.now().timestamp() * 1000)),
         'chat_id': room,
         'isSystem': False
     }
-    
-    # Guardar en store
-    messages_store.append(message)
-    
-    # CRÍTICO: Emitir a TODOS en la sala incluyendo sender
-    emit('message', message, room=room, include_self=True)
-    print(f'💬 Mensaje emitido en {room}: "{message["text"][:30]}..." a {len(socketio.server.manager.rooms.get("/", {}).get(room, []))} clientes')
 
-# Función para API REST
+    messages_store.append(message)
+
+    print(f'💬 Mensaje de {verified_user_id} ({sender_name}) en {room}: "{message["text"][:30]}..."')
+
+    emit('message', message, room=room, include_self=True)
+
+    room_clients = socketio.server.manager.rooms.get("/", {}).get(room, [])
+    print(f'📡 Mensaje distribuido a {len(room_clients)} clientes en sala {room}')
+
+@socketio.on('update_user_info')
+def handle_update_user_info(data):
+    if request.sid in connected_users:
+        old_name = connected_users[request.sid]['displayName']
+        new_name = data.get('displayName', old_name)
+
+        connected_users[request.sid]['displayName'] = new_name
+
+        print(f'📝 Usuario {connected_users[request.sid]["userId"]} cambió nombre: "{old_name}" → "{new_name}"')
+
+        emit('user_info_updated', {
+            'userId': connected_users[request.sid]['userId'],
+            'displayName': new_name,
+            'timestamp': datetime.now().isoformat()
+        })
+
+# Función para API
 
 def get_messages_for_api(chat_id='global'):
     room_messages = [msg for msg in messages_store if msg.get('chat_id') == chat_id]
     return room_messages[-50:] if room_messages else []
+
+def get_connected_users_info():
+    return {
+        'total': len(connected_users),
+        'users': list(connected_users.values())
+    }

--- a/static/chat-widget/src/socket.ts
+++ b/static/chat-widget/src/socket.ts
@@ -1,4 +1,8 @@
 import { io } from 'socket.io-client';
+import UserManager from './utils/userManager';
+
+const userManager = UserManager.getInstance();
+const userSession = userManager.initializeUser();
 
 export const socket = io('/', {
   path: '/socket.io',
@@ -9,22 +13,28 @@ export const socket = io('/', {
   reconnectionAttempts: 10,
   reconnectionDelay: 1000,
   timeout: 20000,
-  forceNew: true
+  forceNew: false,
+  auth: {
+    userId: userSession.userId,
+    displayName: userSession.displayName
+  }
 });
 
-// Logs detallados para debug
+// Logs detallados con userId
 socket.on('connect', () => {
-  console.log('🟢 Socket CONECTADO:', socket.id);
+  console.log('🟢 Socket CONECTADO:', socket.id, 'Usuario:', userSession.userId);
 });
 
 socket.on('disconnect', (reason) => {
-  console.log('🔴 Socket DESCONECTADO:', reason);
+  console.log('🔴 Socket DESCONECTADO:', reason, 'Usuario:', userSession.userId);
 });
 
 socket.on('connect_error', (error) => {
-  console.error('❌ ERROR de conexión:', error.message);
+  console.error('❌ ERROR de conexión:', error.message, 'Usuario:', userSession.userId);
 });
 
-socket.on('status', (data) => {
-  console.log('📊 Status del servidor:', data);
+socket.on('reconnect', (attemptNumber) => {
+  console.log('🔄 Reconectado después de', attemptNumber, 'intentos. Usuario:', userSession.userId);
 });
+
+export { userManager };

--- a/static/chat-widget/src/utils/userManager.ts
+++ b/static/chat-widget/src/utils/userManager.ts
@@ -1,0 +1,105 @@
+interface UserSession {
+  userId: string;
+  displayName: string;
+  sessionStart: number;
+  isLocked: boolean;
+}
+
+class UserManager {
+  private static instance: UserManager;
+  private userSession: UserSession | null = null;
+
+  private constructor() {}
+
+  static getInstance(): UserManager {
+    if (!UserManager.instance) {
+      UserManager.instance = new UserManager();
+    }
+    return UserManager.instance;
+  }
+
+  private generateUserId(): string {
+    const timestamp = Date.now().toString(36);
+    const random = Math.random().toString(36).substr(2, 5);
+    return `user_${timestamp}_${random}`;
+  }
+
+  private generateDefaultName(userId: string): string {
+    const shortId = userId.split('_')[2] || 'anon';
+    return `Usuario_${shortId}`;
+  }
+
+  initializeUser(): UserSession {
+    const existing = localStorage.getItem('chatUserSession');
+    if (existing) {
+      try {
+        this.userSession = JSON.parse(existing);
+        console.log('🔄 Sesión de usuario restaurada:', this.userSession.userId);
+        return this.userSession;
+      } catch {
+        console.warn('⚠️ Error restaurando sesión, creando nueva');
+      }
+    }
+    const userId = this.generateUserId();
+    this.userSession = {
+      userId,
+      displayName: this.generateDefaultName(userId),
+      sessionStart: Date.now(),
+      isLocked: false,
+    };
+    this.saveSession();
+    console.log('✨ Nueva sesión de usuario creada:', userId);
+    return this.userSession;
+  }
+
+  updateDisplayName(name: string): void {
+    if (this.userSession) {
+      this.userSession.displayName = name;
+      this.saveSession();
+    }
+  }
+
+  lockName(): void {
+    if (this.userSession) {
+      this.userSession.isLocked = true;
+      this.saveSession();
+    }
+  }
+
+  unlockName(): void {
+    if (this.userSession) {
+      this.userSession.isLocked = false;
+      this.saveSession();
+    }
+  }
+
+  private saveSession(): void {
+    if (this.userSession) {
+      localStorage.setItem('chatUserSession', JSON.stringify(this.userSession));
+    }
+  }
+
+  getCurrentUser(): UserSession | null {
+    return this.userSession;
+  }
+
+  getUserId(): string {
+    return this.userSession?.userId || 'anonymous';
+  }
+
+  getDisplayName(): string {
+    return this.userSession?.displayName || 'Anónimo';
+  }
+
+  isNameLocked(): boolean {
+    return this.userSession?.isLocked || false;
+  }
+
+  resetSession(): void {
+    localStorage.removeItem('chatUserSession');
+    this.userSession = null;
+  }
+}
+
+export default UserManager;
+export type { UserSession };


### PR DESCRIPTION
## Summary
- manage per-user sessions with `userManager`
- include user ID in Socket.IO auth and handle user events server-side
- update ChatModal to use new user manager and ignore echo messages
- expose connected users via new `/api/debug/users` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6886f155ec7c83258d09239f1be5ad9a