### PR TITLE
Fix socket message broadcasting

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -162,6 +162,12 @@ def handle_update_user_info(data):
             'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         })
 
+# === Evento simple para reemitir mensajes ===
+@socketio.on('send_message')
+def handle_send_message(data):
+    """Recibe un mensaje del cliente y lo reenvía globalmente"""
+    emit('new_message', data, broadcast=True)
+
 # Función para API (mantener formato BD)
 
 def get_messages_for_api(chat_id='global'):

--- a/static/chat-widget/src/components/ChatModal.tsx
+++ b/static/chat-widget/src/components/ChatModal.tsx
@@ -200,7 +200,7 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
     };
 
     socket.on('connect', onConnect);
-    socket.on('message', onMessage);
+    socket.on('new_message', onMessage);
     socket.on('message_history', onMessageHistory);
     socket.on('user_registered', onUserRegistered);
     socket.on('user_joined', onUserJoined);
@@ -235,7 +235,7 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
       clearInterval(pollInterval);
       socket.emit('leave', { chat_id: chatId, userId: user.userId });
       socket.off('connect', onConnect);
-      socket.off('message', onMessage);
+      socket.off('new_message', onMessage);
       socket.off('message_history', onMessageHistory);
       socket.off('user_registered', onUserRegistered);
       socket.off('user_joined', onUserJoined);
@@ -280,7 +280,7 @@ const ChatModal = ({ isOpen, onClose }: ChatModalProps): JSX.Element | null => {
 
     console.log('📤 Enviando mensaje formato BD desde usuario:', user.userId);
 
-    socket.emit('new_message', msg);
+    socket.emit('send_message', msg);
 
     setInputMessage('');
   };


### PR DESCRIPTION
## Summary
- broadcast chat messages from a new `send_message` event
- listen for `new_message` on the frontend and emit messages with `send_message`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688847265a3883258b7ad8da88ff4c76