### PR TITLE
Fix chat frontend join and message handling

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 import time
 from flask import request
-from flask_socketio import SocketIO, emit, join_room, leave_room
-
-socketio = SocketIO(cors_allowed_origins="*", async_mode="eventlet")
+from flask_socketio import emit, join_room, leave_room
+from extensions import socketio
 
 # Almacén de mensajes en memoria y usuarios conectados
 messages_store: list[dict] = []


### PR DESCRIPTION
## Summary
- connect to the SocketIO room with user info on mount
- listen for `new_message` and initial `message_history`
- clean up listeners when the component unmounts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68885eb65f948325b7aabd282807a0af