### PR TITLE
Fix import error in sockets

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import time
-from flask_socketio import emit, join_room, leave_room, request
+from flask_socketio import emit, join_room, leave_room
+from flask import request  # import request from Flask, not flask_socketio
 from extensions import socketio
 from pydantic import BaseModel, ValidationError
 


### PR DESCRIPTION
## Summary
- fix import for request in sockets module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68887d622a6483259dcc386f751bd757