### PR TITLE
Fix missing python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ google-api-python-client>=2.127
 flask-socketio>=5.3.0
 
 pydantic>=2.7
+python-dotenv


### PR DESCRIPTION
## Summary
- install **python-dotenv**

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688c56a56a408325bd04450db3d94955