### PR TITLE
fix: import request from flask

### DIFF
--- a/sockets.py
+++ b/sockets.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import time
-from flask_socketio import emit, join_room, leave_room, request
+from flask_socketio import emit, join_room, leave_room
+from flask import request
 from extensions import socketio
 from pydantic import BaseModel, ValidationError
 


### PR DESCRIPTION
## Summary
- correct request import in sockets to come from flask instead of flask_socketio

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688d7e852b508325ba94bf90a115af20